### PR TITLE
Fix for issue with built in php suggester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
+## [0.4.1] - 2017-03-29
+- Fix for issue causing built in php intellisense to be broken
+- Add code coverage to CI and more unit tests to get full code coverage
+
 ## [0.4.0] - 2017-03-17
 - Add Inferring of types in properties
 - Add Inferring of types using function param defaults
@@ -38,7 +42,8 @@ All notable changes to the "php-docblocker" extension will be documented in this
 ## 0.1.0 - 2017-03-12
 - Initial release
 
-[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/neild3r/vscode-php-docblocker/compare/v0.3.1...v0.3.2

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "php-docblocker",
   "displayName": "PHP DocBlocker",
   "description": "A simple, dependency free PHP specific DocBlocking package",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "neilbrayfield",
   "author": "Neil Brayfield <dev@brayfield.uk>",
   "engines": {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -54,7 +54,7 @@ export default class Completions implements CompletionItemProvider
             result.push(block);
         }
 
-        let match = part.match(/.*?\* (@[a-z]+)$/);
+        let match = part.match(/.*?\* (@[a-z]*)$/);
 
         if (match == null) {
             return result;
@@ -66,7 +66,7 @@ export default class Completions implements CompletionItemProvider
             return tag.tag.match(prefix) !== null;
         });
 
-        let range:Range = document.getWordRangeAtPosition(position, /@[a-z]+/);
+        let range:Range = document.getWordRangeAtPosition(position, /@[a-z]*/);
 
         potential.forEach(tag => {
             let item = new CompletionItem(tag.tag, CompletionItemKind.Snippet);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import Completions from "./completions";
 
 export function activate(context: vscode.ExtensionContext) {
     vscode.languages.setLanguageConfiguration('php', {
-        wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
+        wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
         onEnterRules: [
             {
                 // e.g. /** | */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import Completions from "./completions";
 
 export function activate(context: vscode.ExtensionContext) {
     vscode.languages.setLanguageConfiguration('php', {
+        wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
         onEnterRules: [
             {
                 // e.g. /** | */
@@ -29,12 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
         ]
     });
 
-    vscode.languages.registerCompletionItemProvider(
-        'php',
-        new Completions(),
-        '*', '@', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-        'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u','v', 'w', 'x', 'y'
-    );
+    vscode.languages.registerCompletionItemProvider('php', new Completions(), '*', '@');
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import Completions from "./completions";
 
 export function activate(context: vscode.ExtensionContext) {
     vscode.languages.setLanguageConfiguration('php', {
-        wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
+        wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
         onEnterRules: [
             {
                 // e.g. /** | */


### PR DESCRIPTION
When adding in the enter rules we accidentally destroy the word pattern that the built in suggesters rely on, this PR restores them. Really we need a way of extending the config instead of overwriting but at the moment that isn't possible I don't believe.

Fixes #20 