### PR TITLE
Add support for PHP7.1 nullable types

### DIFF
--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -30,16 +30,18 @@ export default class FunctionBlock extends Block
             let args = argString.split(',');
             for (let index = 0; index < args.length; index++) {
                 let arg = args[index];
-                let parts = arg.match(/^\s*([A-Za-z0-9_\\]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
+                let parts = arg.match(/^\s*(\?)?\s*([A-Za-z0-9_\\]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
                 var type = '[type]';
 
-                if (parts[1] != null) {
-                    type = parts[1];
-                } else if (parts[3] != null && parts[3] != "") {
-                    type = this.getTypeFromValue(parts[3]);
+                if (parts[2] != null && parts[1] === '?') {
+                    type = parts[2]+'|null';
+                } else if (parts[2] != null) {
+                    type = parts[2];
+                } else if (parts[4] != null && parts[4] != "") {
+                    type = this.getTypeFromValue(parts[4]);
                 }
 
-                doc.params.push(new Param(type, parts[2]));
+                doc.params.push(new Param(type, parts[3]));
             }
         }
 

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -43,10 +43,10 @@ export default class FunctionBlock extends Block
             }
         }
 
-        let returnType:Array<string> = this.signiture.match(/.*\)\s*\:\s*([a-zA-Z\\]+)\s*$/m);
+        let returnType:Array<string> = this.signiture.match(/.*\)\s*\:\s*(\?)?\s*([a-zA-Z\\]+)\s*$/m);
 
         if (returnType != null) {
-            doc.return = returnType[1];
+            doc.return = (returnType[1] === '?') ? returnType[2]+'|null' : returnType[2];
         } else {
             doc.return = this.getReturnFromName(params[5]);
         }

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -63,6 +63,16 @@ abstract class Test
     ) {
     }
 
+    ////=> nullable-return-type
+    public function nullableReturnType(): ?string
+    {
+    }
+
+    ////=> nullable-args
+    public function nullableArgs(?TypeHint $var, ?\Type2 $var2, ?string $var3)
+    {
+    }
+
     ////=> param-types
     public function getParamTypes(
         TypeHint $hint,

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -148,6 +148,35 @@
         }
     },
     {
+        "key": "nullable-return-type",
+        "name": "Nullable return type",
+        "result": {
+            "return": "string|null",
+            "params": []
+        }
+    },
+    {
+        "key": "nullable-args",
+        "name": "Nullable args",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$var",
+                    "type": "TypeHint|null"
+                },
+                {
+                    "name": "$var2",
+                    "type": "\\Type2|null"
+                },
+                {
+                    "name": "$var3",
+                    "type": "string|null"
+                }
+            ]
+        }
+    },
+    {
         "key": "param-types",
         "name": "All param types",
         "result": {


### PR DESCRIPTION
Adds support for both nullable argument types and return types.

Fixes #40 