### PR TITLE
Don't prefix method name with $

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -78,7 +78,7 @@ export default class Completions implements CompletionItemProvider
         },
         {
             tag: '@method',
-            snippet: '@method ${1:mixed} \$${2:methodName()}'
+            snippet: '@method ${1:mixed} ${2:methodName()}'
         },
         {
             tag: '@package',


### PR DESCRIPTION
Changed autocompletion for `@method` from:

```
@method mixed $methodName()
```
to
```
@method mixed methodName()
```
