### PR TITLE
Improve the block placement in vscode 1.17

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -164,7 +164,8 @@ export default class Completions implements CompletionItemProvider
             let documenter:Documenter = new Documenter(match, window.activeTextEditor);
 
             let block = new CompletionItem("/**", CompletionItemKind.Snippet);
-            block.range = match;
+            let range = document.getWordRangeAtPosition(position, /\/\*\* \*\//);
+            block.range = range;
             block.insertText = documenter.autoDocument();
             result.push(block);
 

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -164,7 +164,7 @@ export class Doc
             }
         }
 
-        snippet.appendText("\n");
+        snippet.appendText("\n */");
 
         return snippet;
     }

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -4,7 +4,7 @@
         "expected": [
             "/**",
             " * ${1}",
-            ""
+            " */"
         ]
     },
     {
@@ -21,7 +21,7 @@
             "/**",
             " * ${1:Undocumented var}",
             " * @var ${2:mixed}",
-            ""
+            " */"
         ]
     },
     {
@@ -46,7 +46,7 @@
             " *",
             " * @param ${2:int} ${3:\\$name}",
             " * @return ${4:void}",
-            ""
+            " */"
         ]
     },
     {
@@ -65,7 +65,7 @@
             " * ${1:Undocumented function}",
             " *",
             " * @author John Smith <john@smith.com>",
-            ""
+            " */"
         ]
     },
     {
@@ -91,7 +91,7 @@
             " *",
             " * @param ${2:int} ${3:\\$name}",
             " * @author John Smith <john@smith.com>",
-            ""
+            " */"
         ]
     },
     {
@@ -113,7 +113,7 @@
             "/**",
             " * ${1:Undocumented function}",
             " * @param ${2:int} ${3:\\$name}",
-            ""
+            " */"
         ]
     }
 ]


### PR DESCRIPTION
As the newer version of vscode puts the ending `*/` in for us we need to compensate. The previous fix just excluded it but now we end up with the end of the snippet being before the vscode inserted `*/`.

Instead of doing this this just updates the context of the snippet to replace that ending too.

fixes #64 