### PR TITLE
Fixed: typo in signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 Basic PHP DocBlocking extension.
 
-We now have a set of unit tests and some full coverage on the parsing of signitures as well as continuous integration. This should ensure the extension remains stable as development progresses.
+We now have a set of unit tests and some full coverage on the parsing of signatures as well as continuous integration. This should ensure the extension remains stable as development progresses.
 
 ## Features
 
 * Completion snippet after `/**` above a class, function, class property
 * Continuation of DocBlock when pressing enter when in a DocBlock
 * Completion of DocBlock tags such as `@param`, `@return`, `@throws`
-* Inferring of param and return types from signitures
+* Inferring of param and return types from signatures
 
 ## Requirements
 


### PR DESCRIPTION
fixed a typo in "signitures" and changed it to "signatures"