### PR TITLE
Add the short property syntax and rework the var to be a Param

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This extension contributes the following settings:
 * `php-docblocker.extra`: an array of extra tags to add to each DocBlock (These can include tabstops and snippet variables)
 * `php-docblocker.useShortNames`: Whether we should use short type names. e.g. bool or boolean
 * `php-docblocker.author`: An object containing your default author tag settings
+* `php-docblocker.singleLineProperty`: Enables the single line variable syntax
 
 ## Supported DocBlock tags
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,12 @@
         "php-docblocker.useShortNames": {
           "type": "boolean",
           "default": false,
-          "description": "Wether you want to use integer instead of int and boolean instead of bool."
+          "description": "Whether you want to use integer instead of int and boolean instead of bool."
+        },
+        "php-docblocker.singleLineProperty": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables the single line variable syntax"
         },
         "php-docblocker.author": {
           "type": "object",

--- a/src/block/property.ts
+++ b/src/block/property.ts
@@ -20,12 +20,15 @@ export default class Property extends Block
         let params = this.match();
 
         let doc = new Doc('Undocumented variable');
+        let type;
 
         if (params[5]) {
-            doc.var = this.getTypeFromValue(params[5]);
+            type = this.getTypeFromValue(params[5]);
         } else {
-            doc.var = '[type]';
+            type = '[type]';
         }
+
+        doc.var = new Param(type, params[4]);
 
         return doc;
     }

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -25,9 +25,9 @@ export class Doc
     /**
      * Var tag
      *
-     * @type {string}
+     * @type {Param}
      */
-    public var:string;
+    public var:Param;
 
     /**
      * The message portion of the block
@@ -64,7 +64,7 @@ export class Doc
             this.return = input.return;
         }
         if (input.var !== undefined) {
-            this.var = input.var;
+            this.var = new Param(input.var.type, input.var.name);
         }
         if (input.message !== undefined) {
             this.message = input.message;
@@ -120,6 +120,19 @@ export class Doc
         let stop = 2;
 
         snippet.appendText("/**");
+
+        if (this.var && this.getConfig().singleLineProperty) {
+            snippet.appendText(" @var ");
+            snippet.appendVariable('1', this.var.type);
+            snippet.appendText(" ");
+            snippet.appendVariable('2', this.var.name);
+            snippet.appendText(" ");
+            snippet.appendVariable('3', this.message);
+            snippet.appendText(" */");
+
+            return snippet;
+        }
+
         snippet.appendText("\n * ");
         snippet.appendVariable('1', this.message);
 
@@ -142,7 +155,7 @@ export class Doc
                 gap = true;
             }
             snippet.appendText("\n * @var ");
-            snippet.appendVariable(stop++ + '', this.var);
+            snippet.appendVariable(stop++ + '', this.var.type);
         }
 
         if (this.return) {

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -31,7 +31,10 @@
         },
         "input": {
             "message": "Undocumented var",
-            "var": "mixed"
+            "var": {
+                "type" : "mixed",
+                "name" : "$prop"
+            }
         },
         "expected": [
             "/**",
@@ -184,6 +187,22 @@
             " *",
             " * @return ${4:void}",
             " */"
+        ]
+    },
+    {
+        "name": "Single line property",
+        "config": {
+            "singleLineProperty": true
+        },
+        "input": {
+            "message": "Undocumented variable",
+            "var": {
+                "type" : "array",
+                "name" : "$prop"
+            }
+        },
+        "expected": [
+            "/** @var ${1:array} ${2:\\$prop} ${3:Undocumented variable} */"
         ]
     }
 ]

--- a/test/fixtures/properties.php.json
+++ b/test/fixtures/properties.php.json
@@ -2,76 +2,121 @@
     {
         "key": "public",
         "name": "Public",
-        "var": "[type]"
+        "var": {
+            "type": "[type]",
+            "name": "$public"
+        }
     },
     {
         "key": "protected",
         "name": "Protected",
-        "var": "[type]"
+        "var": {
+            "type": "[type]",
+            "name": "$protected"
+        }
     },
     {
         "key": "static",
         "name": "Static",
-        "var": "[type]"
+        "var": {
+            "type": "[type]",
+            "name": "$static"
+        }
     },
     {
         "key": "static-alternate",
         "name": "Static Alternate",
-        "var": "[type]"
+        "var": {
+            "type": "[type]",
+            "name": "$staticAlt"
+        }
     },
     {
         "key": "default-string",
         "name": "Default String",
-        "var": "string"
+        "var": {
+            "type": "string",
+            "name": "$defaultString"
+        }
     },
     {
         "key": "default-string-alternate",
         "name": "Default String Alternate",
-        "var": "string"
+        "var": {
+            "type": "string",
+            "name": "$defaultStringAlternate"
+        }
     },
     {
         "key": "default-bool",
         "name": "Default Bool",
-        "var": "boolean"
+        "var": {
+            "type": "boolean",
+            "name": "$defaultBool"
+        }
     },
     {
         "key": "default-bool-alternate",
         "name": "Default Bool Alternate",
-        "var": "boolean"
+        "var": {
+            "type": "boolean",
+            "name": "$defaultBoolAlternate"
+        }
     },
     {
         "key": "default-array",
         "name": "Default Array",
-        "var": "array"
+        "var": {
+            "type": "array",
+            "name": "$defaultArray"
+        }
     },
     {
         "key": "default-array-alternate",
         "name": "Default Array Alternate",
-        "var": "array"
+        "var": {
+            "type": "array",
+            "name": "$defaultArrayAlternate"
+        }
     },
     {
         "key": "multiline",
         "name": "Multiline",
-        "var": "array"
+        "var": {
+            "type": "array",
+            "name": "$multiline"
+        }
     },
     {
         "key": "multiline-alternate",
         "name": "Multiline Alternate",
-        "var": "array"
+        "var": {
+            "type": "array",
+            "name": "$multilineAlternate"
+        }
     },
     {
         "key": "default-float",
         "name": "Default Float",
-        "var": "float"
+        "var": {
+            "type": "float",
+            "name": "$defaultFloat"
+        }
     },
     {
         "key": "default-int",
         "name": "Default Int",
-        "var": "integer"
+        "var": {
+            "type": "integer",
+            "name": "$defaultInt"
+        }
     },
     {
         "key": "default-null",
         "name": "Default Null",
-        "var": "[type]"
+        "var": {
+            "type": "[type]",
+            "name": "$defaultNull"
+        }
     }
 ]

--- a/test/properties.test.ts
+++ b/test/properties.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import {TextEditor, TextDocument} from 'vscode';
 import Helper from './helpers';
-import Function from '../src/block/property';
+import Property from '../src/block/property';
 import {Doc, Param} from '../src/doc';
 
 suite("Property tests", () => {
@@ -22,19 +22,19 @@ suite("Property tests", () => {
 
     map.forEach(testData => {
         test("Match Test: "+ testData.name, () => {
-            let func = new Function(testPositions[testData.key], editor);
+            let func = new Property(testPositions[testData.key], editor);
             assert.equal(func.test(), true, test.name);
         });
 
         test("Parse Test: "+ testData.name, () => {
-            let func = new Function(testPositions[testData.key], editor);
+            let func = new Property(testPositions[testData.key], editor);
             assert.ok(func.parse(), test.name);
         });
 
         test("Type Test: "+ testData.name, () => {
-            let func = new Function(testPositions[testData.key], editor);
+            let func = new Property(testPositions[testData.key], editor);
             let doc:Doc = func.parse();
-            assert.equal(doc.var, testData.var, test.name);
+            assert.deepEqual(doc.var, new Param(testData.var.type, testData.var.name), test.name);
         });
     });
 });


### PR DESCRIPTION
The first part of #42 

This only deals with having the short syntax for the currently existing property blocks. If we want to support variables as well we'll need an additional PR