### PR TITLE
When outputting automatic params, do not tab stop on the variable name

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -103,7 +103,7 @@ export class Doc
                 snippet.appendText("\n * @param ");
                 snippet.appendVariable(stop++ + '', param.type);
                 snippet.appendText(" ");
-                snippet.appendVariable(stop++ + '', param.name);
+                snippet.appendText(param.name);
             });
         }
 

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -60,8 +60,8 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int} ${3:\\$name}",
-            " * @return ${4:void}",
+            " * @param ${2:int} \\$name",
+            " * @return ${3:void}",
             " */"
         ]
     },
@@ -105,7 +105,7 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int} ${3:\\$name}",
+            " * @param ${2:int} \\$name",
             " * @author John Smith <john@smith.com>",
             " */"
         ]
@@ -128,7 +128,7 @@
         "expected": [
             "/**",
             " * ${1:Undocumented function}",
-            " * @param ${2:int} ${3:\\$name}",
+            " * @param ${2:int} \\$name",
             " */"
         ]
     },
@@ -154,7 +154,7 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int} ${3:\\$name}",
+            " * @param ${2:int} \\$name",
             " *",
             " * @author John Smith <john@smith.com>",
             " */"
@@ -180,9 +180,9 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int} ${3:\\$name}",
+            " * @param ${2:int} \\$name",
             " *",
-            " * @return ${4:void}",
+            " * @return ${3:void}",
             " */"
         ]
     }


### PR DESCRIPTION
When you are manually creating a `@param`, it makes sense to tab stop on the variable name, as you are going to provide it manually.

But when creating the docblock automatically, it does not make sense to have automatically detected function params have a tab stop on the param's variable name. You literally just extracted it from the function definition, so it's going to be correct.