### PR TITLE
Add in a templating system to handle more complex set ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ to true.
     }
 ```
 
+#### Configured function with extra content and placeholders
+
+The example below won't have a return tag and will add in an author tag with correct placeholders depending on 
+how many options you have. You can put in placeholders by using `###` in place of the tab stop number and it 
+will be calculated at generation time.
+
+```json
+    {
+        "message": {
+            "gapAfter": true
+        },
+        "param": {
+            "gapBefore": true
+        },
+        "author": {
+            "content": "@author ${###:Neil Brayfield} <${###:neil@test.com}>"
+        }
+    }
+```
+
 ## Supported DocBlock tags
 
 Please see below for a list of supported tags and their snippets. These tags are available within a DocBlock

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ config option per key to add additional control.
 
 #### Supported template keys
 
-| Key             | Aplies to type  | Description                                    |
-|-----------------|-----------------|------------------------------------------------|
-| message         | All             | Space for entering a description of your block |
-| extra           | All             | Adds in your custom tags from the extra config |
-| param           | Function        | Function @param items                          |
-| return          | Function        | Function @return item                          |
-| var             | Property        | Property @var item                             |
+| Key             | Aplies to type  | Description                                                                       |
+|-----------------|-----------------|-----------------------------------------------------------------------------------|
+| message         | All             | Space for entering a description of your block                                    |
+| extra           | All             | Adds in your custom tags from the extra config                                    |
+| param           | Function        | Function @param items                                                             |
+| return          | Function        | Function @return item                                                             |
+| var             | Property        | Property @var item                                                                |
+| *               | All             | This is for any key that is unmatched you can use the content option to add a tag |
 
 #### Supported template config options
 
@@ -69,6 +70,7 @@ config option per key to add additional control.
 |-----------------|------------------|------------------------------------------------|
 | gapBefore       | All              | Adds a gap before the tag section starts       |
 | gapAfter        | All              | Adds a gap after the tag section ends          |
+| content         | *                | Adds a gap after the tag section ends          |
 
 #### Configured function template example
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ config option per key to add additional control.
     }
 ```
 
-##### Supported template keys
+#### Supported template keys
 
 | Key             | Aplies to type  | Description                                    |
 |-----------------|-----------------|------------------------------------------------|
@@ -62,14 +62,14 @@ config option per key to add additional control.
 | return          | Function        | Function @return item                          |
 | var             | Property        | Property @var item                             |
 
-##### Supported template config options
+#### Supported template config options
 
 | Option          | Aplies to key(s) | Description                                    |
 |-----------------|------------------|------------------------------------------------|
 | gapBefore       | All              | Adds a gap before the tag section starts       |
 | gapAfter        | All              | Adds a gap after the tag section ends          |
 
-##### Configured function template example
+#### Configured function template example
 
 In the example below we have added some gap configuration and removed the return tag for our template as well as 
 changing the default order. This means we'll never have a @return tag and extra comes before the params. It's also

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We now have a set of unit tests and some full coverage on the parsing of signatu
 * Continuation of DocBlock when pressing enter when in a DocBlock
 * Completion of DocBlock tags such as `@param`, `@return`, `@throws`
 * Inferring of param and return types from signatures
+* Configuration of template for each type of docblock completion
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,65 @@ This extension contributes the following settings:
 * `php-docblocker.useShortNames`: Whether we should use short type names. e.g. bool or boolean
 * `php-docblocker.qualifyClassNames`: When adding type hints for class names search namespace use statements and qualify the class 
 * `php-docblocker.author`: An object containing your default author tag settings
+* `php-docblocker.functionTemplate`: See below for how to set up docblock templates
+* `php-docblocker.propertyTemplate`: See below for how to set up docblock templates
+* `php-docblocker.classTemplate`: See below for how to set up docblock templates
+
+### Templating
+
+If you want more control over the order or gap settings on your docblocks or you want different things for properties vs class templates
+you can start customising the template configuration objects. These are the config options `functionTemplate`, `propertyTemplate` and
+`classTemplate`.
+
+#### Default set up for function
+
+The below is the default set up for a function. The order of the keys represents the output order. There are no specific options in each
+config option per key to add additional control.
+
+```json
+    {
+        "message": {},
+        "param": {},
+        "return": {},
+        "extra": {}
+    }
+```
+
+##### Supported template keys
+
+| Key             | Aplies to type  | Description                                    |
+|-----------------|-----------------|------------------------------------------------|
+| message         | All             | Space for entering a description of your block |
+| extra           | All             | Adds in your custom tags from the extra config |
+| param           | Function        | Function @param items                          |
+| return          | Function        | Function @return item                          |
+| var             | Property        | Property @var item                             |
+
+##### Supported template config options
+
+| Option          | Aplies to key(s) | Description                                    |
+|-----------------|------------------|------------------------------------------------|
+| gapBefore       | All              | Adds a gap before the tag section starts       |
+| gapAfter        | All              | Adds a gap after the tag section ends          |
+
+##### Configured function template example
+
+In the example below we have added some gap configuration and removed the return tag for our template as well as 
+changing the default order. This means we'll never have a @return tag and extra comes before the params. It's also
+worth pointing out that the gapAfter in the message is the same as setting the gap config option in the main config
+to true.
+
+```json
+    {
+        "message": {
+            "gapAfter": true
+        },
+        "extra": {},
+        "param": {
+            "gapBefore": true
+        },
+    }
+```
 
 ## Supported DocBlock tags
 

--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
           "description": "Fully qualifies any data types used in param and returns by reading the namespaces."
         },
         "php-docblocker.functionTemplate": {
-          "type": "array",
-          "default": [
-            "{message}",
-            "{gap}",
-            "{params}",
-            "{returnGap}",
-            "{return}"
-          ],
+          "type": "object",
+          "default": {
+            "message": {},
+            "var": {},
+            "param": {},
+            "return": {},
+            "extra": {}
+          },
           "description": "Specify the default template for functions."
         },
         "php-docblocker.author": {

--- a/package.json
+++ b/package.json
@@ -68,12 +68,28 @@
           "type": "object",
           "default": {
             "message": {},
-            "var": {},
             "param": {},
             "return": {},
             "extra": {}
           },
           "description": "Specify the default template for functions."
+        },
+        "php-docblocker.propertyTemplate": {
+          "type": "object",
+          "default": {
+            "message": {},
+            "var": {},
+            "extra": {}
+          },
+          "description": "Specify the default template for class variables."
+        },
+        "php-docblocker.classTemplate": {
+          "type": "object",
+          "default": {
+            "message": {},
+            "extra": {}
+          },
+          "description": "Specify the default template for classes."
         },
         "php-docblocker.author": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,17 @@
           "default": false,
           "description": "Fully qualifies any data types used in param and returns by reading the namespaces."
         },
+        "php-docblocker.functionTemplate": {
+          "type": "array",
+          "default": [
+            "{message}",
+            "{gap}",
+            "{params}",
+            "{returnGap}",
+            "{return}"
+          ],
+          "description": "Specify the default template for functions."
+        },
         "php-docblocker.author": {
           "type": "object",
           "default": {

--- a/src/block/class.ts
+++ b/src/block/class.ts
@@ -1,5 +1,6 @@
 import { Block } from "../block";
 import { Doc, Param } from "../doc";
+import Config from "../util/config";
 
 /**
  * Represents a class block
@@ -18,6 +19,7 @@ export default class Class extends Block
     {
         let params = this.match();
         let doc = new Doc('Undocumented '+ params[2]);
+        doc.template = Config.instance.get('classTemplate');
 
         return doc;
     }

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -26,6 +26,7 @@ export default class FunctionBlock extends Block
         let params = this.match();
 
         let doc = new Doc('Undocumented function');
+        doc.template = Config.instance.get('functionTemplate');
         let argString = this.getEnclosed(params[6], "(", ")");
         let head:string;
 

--- a/src/block/property.ts
+++ b/src/block/property.ts
@@ -1,5 +1,6 @@
 import { Block } from "../block";
 import { Doc, Param } from "../doc";
+import Config from "../util/config";
 
 /**
  * Represents an property block
@@ -20,6 +21,7 @@ export default class Property extends Block
         let params = this.match();
 
         let doc = new Doc('Undocumented variable');
+        doc.template = Config.instance.get('propertyTemplate');
 
         if (params[5]) {
             doc.var = this.getTypeFromValue(params[5]);

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -101,7 +101,7 @@ export class Doc
             extra = [];
         }
 
-        if (this.message != null) {
+        if (this.message != '') {
             messageString = "\${###" + (this.message != "" ? ':' : '') + this.message + "}";
         }
 

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -40,9 +40,9 @@ export class Doc
     /**
      * Define the template for the documentor
      *
-     * @type {Array<string>}
+     * @type {Object}
      */
-    protected _template:Array<string>;
+    protected _template:Object;
 
     /**
      * Creates an instance of Doc.
@@ -55,7 +55,7 @@ export class Doc
     }
 
     /**
-     * Set class properties from a standard object
+     * Set class properties from a standard*
      *
      * @param {*} input
      */
@@ -90,13 +90,11 @@ export class Doc
         let gap = Config.instance.get('gap');
         let returnGap = Config.instance.get('returnGap');
 
-        let returnString = "-";
-        let varString = "-";
-        let gapString = gap ? "" : "-";
-        let returnGapString = "-";
-        let paramString = "-";
-        let extraString = "-";
-        let messageString = "-";
+        let returnString = "";
+        let varString = "";
+        let paramString = "";
+        let extraString = "";
+        let messageString = "";
 
         if (isEmpty) {
             gap = true;
@@ -136,23 +134,48 @@ export class Doc
             }
         }
 
-        if (gap && varString == "-" && returnString == "-" && extraString == "-"  && paramString == "-") {
-            gapString = "-";
+
+        let templateArray = [];
+        for (let key in this.template) {
+            let propConfig = this.template[key];
+            let propString:string;
+            if (key == 'message' && messageString) {
+                propString = messageString;
+                if (gap) {
+                    propConfig.gapAfter = true;
+                }
+            } else if (key == 'var' && varString) {
+                propString = varString;
+            } else if (key == 'return' && returnString) {
+                propString = returnString;
+                if (returnGap) {
+                    propConfig.gapBefore = true;
+                }
+            } else if (key == 'param' && paramString) {
+                propString = paramString;
+            } else if (key == 'extra' && extraString) {
+                propString = extraString;
+            }
+
+            if (propString && propConfig.gapBefore) {
+                templateArray.push("");
+            }
+
+            if (propString) {
+                templateArray.push(propString);
+            }
+
+            if (propString && propConfig.gapAfter) {
+                templateArray.push("");
+            }
         }
 
-        if (returnGap && returnString != "-" && paramString != "-") {
-            returnGapString = "";
+        if (templateArray[templateArray.length - 1] == "") {
+            templateArray.pop();
         }
 
-        let templateString:string = this.template.join("\n");
+        let templateString:string = templateArray.join("\n");
         templateString = "/**\n" + templateString + "\n */";
-        templateString = templateString.replace(/{message}/gm, messageString);
-        templateString = templateString.replace(/{var}/gm, varString);
-        templateString = templateString.replace(/{return}/gm, returnString);
-        templateString = templateString.replace(/{params}/gm, paramString);
-        templateString = templateString.replace(/{gap}/gm, gapString);
-        templateString = templateString.replace(/{returnGap}/gm, returnGapString);
-        templateString = templateString.replace(/{extra}/gm, extraString);
 
         let stop = 0;
         templateString = templateString.replace(/###/gm, function():string {
@@ -160,9 +183,8 @@ export class Doc
             return stop + "";
         });
 
-        templateString = templateString.replace(/\n-(?=\n)/gm, "");
+        templateString = templateString.replace(/^$/gm, " *");
         templateString = templateString.replace(/^(?!(\s\*|\/\*))/gm, " * $1");
-        templateString = templateString.replace(/^\s\*\s\n/gm, " *\n");
 
         let snippet = new SnippetString(templateString);
 
@@ -172,9 +194,9 @@ export class Doc
     /**
      * Set the template for rendering
      *
-     * @param {Array<string>} template
+     * @param {Object} template
      */
-    public set template(template:Array<string>)
+    public set template(template:Object)
     {
         this._template = template;
     }
@@ -182,20 +204,18 @@ export class Doc
     /**
      * Get the template
      *
-     * @type {Array<string>}
+     * @type {Object}
      */
-    public get template():Array<string>
+    public get template():Object
     {
         if (this._template == null) {
-            return [
-                "{message}",
-                "{gap}",
-                "{var}",
-                "{params}",
-                "{returnGap}",
-                "{return}",
-                "{extra}"
-            ];
+            return {
+                message: {},
+                var: {},
+                param: {},
+                return: {},
+                extra: {}
+            }
         }
 
         return this._template;
@@ -203,7 +223,7 @@ export class Doc
 }
 
 /**
- * A simple paramter object
+ * A simple paramter*
  */
 export class Param
 {

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -55,7 +55,7 @@ export class Doc
     }
 
     /**
-     * Set class properties from a standard*
+     * Set class properties from a standard object
      *
      * @param {*} input
      */
@@ -101,9 +101,7 @@ export class Doc
             extra = [];
         }
 
-        if (this.message != '') {
-            messageString = "\${###" + (this.message != "" ? ':' : '') + this.message + "}";
-        }
+        messageString = "\${###" + (this.message != "" ? ':' : '') + this.message + "}";
 
         if (this.params.length) {
             paramString = "";
@@ -223,7 +221,7 @@ export class Doc
 }
 
 /**
- * A simple paramter*
+ * A simple paramter object
  */
 export class Param
 {

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -122,14 +122,7 @@ export class Doc
         }
 
         if (Array.isArray(extra) && extra.length > 0) {
-            extraString = "";
-            for (var index = 0; index < extra.length; index++) {
-                var element = extra[index];
-                if (index > 0) {
-                    extraString += "\n";
-                }
-                extraString += element;
-            }
+            extraString = extra.join("\n");
         }
 
 
@@ -153,6 +146,8 @@ export class Doc
                 propString = paramString;
             } else if (key == 'extra' && extraString) {
                 propString = extraString;
+            } else if (propConfig.content !== undefined) {
+                propString = propConfig.content;
             }
 
             if (propString && propConfig.gapBefore && templateArray[templateArray.length - 1] != "") {

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -155,7 +155,7 @@ export class Doc
                 propString = extraString;
             }
 
-            if (propString && propConfig.gapBefore) {
+            if (propString && propConfig.gapBefore && templateArray[templateArray.length - 1] != "") {
                 templateArray.push("");
             }
 

--- a/test/doc.test.ts
+++ b/test/doc.test.ts
@@ -21,6 +21,9 @@ suite("Snippet build tests", () => {
             } else {
                 empty = true;
             }
+            if (Config.instance.get('template')) {
+                doc.template = Config.instance.get('template');
+            }
             assert.equal(doc.build(empty).value, testData.expected.join("\n"));
         });
     });

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -255,5 +255,40 @@
             " * @param ${2:int} \\$name",
             " */"
         ]
+    },
+    {
+        "name": "Function template",
+        "config": {
+            "template": {
+                "message": {
+                    "gapAfter": true
+                },
+                "author": {
+                    "content": "@author Neil Brayfield <neil@test.com>"
+                },
+                "param": {
+                    "gapBefore": true
+                }
+            }
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$name",
+                    "type": "int"
+                }
+            ],
+            "return": "void"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @author Neil Brayfield <neil@test.com>",
+            " *",
+            " * @param ${2:int} \\$name",
+            " */"
+        ]
     }
 ]

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -290,5 +290,40 @@
             " * @param ${2:int} \\$name",
             " */"
         ]
+    },
+    {
+        "name": "Function template with placeholders",
+        "config": {
+            "template": {
+                "message": {
+                    "gapAfter": true
+                },
+                "author": {
+                    "content": "@author ${###:Neil Brayfield} <${###:neil@test.com}>"
+                },
+                "param": {
+                    "gapBefore": true
+                }
+            }
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$name",
+                    "type": "int"
+                }
+            ],
+            "return": "void"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @author ${2:Neil Brayfield} <${3:neil@test.com}>",
+            " *",
+            " * @param ${4:int} \\$name",
+            " */"
+        ]
     }
 ]

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -67,6 +67,36 @@
         ]
     },
     {
+        "name": "Function multiple params",
+        "config": {
+            "gap": true,
+            "extra": []
+        },
+        "input": {
+            "message": "Undocumented function",
+            "return": "void",
+            "params": [
+                {
+                    "name": "$name",
+                    "type": "int"
+                },
+                {
+                    "name": "$message",
+                    "type": "string"
+                }
+            ]
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @param ${2:int} \\$name",
+            " * @param ${3:string} \\$message",
+            " * @return ${4:void}",
+            " */"
+        ]
+    },
+    {
         "name": "Extra",
         "config": {
             "gap": true,

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -40,6 +40,7 @@ suite("Function tests", () => {
             let actual:Doc = func.parse();
             let expected:Doc = new Doc('Undocumented function');
             expected.fromObject(testData.result);
+            expected.template = Helper.getConfig().get('functionTemplate');
             assert.deepEqual(actual, expected);
         });
     });


### PR DESCRIPTION
This is the start of a change to add a templating system in to the package to allow for uses to do a more advanced configuration of how they want their docblocks to be displayed and would allow people to move things around or remove params by creating their own templates.

The key difficulty I have at the moment is with the old configs for adding in gaps which could now be made redundant but also for what happens to gaps when certain parameters aren't defined such as a gap between params and return when there is no return or no params or neither. Perhaps this change can make things a bit too messy