### PR TITLE
Re-parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,16 @@
   "icon": "images/logo.png",
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [{
-      "command": "php-docblocker.trigger",
-      "title": "Insert PHP Docblock"
-    }],
+    "commands": [
+      {
+        "command": "php-docblocker.trigger",
+        "title": "Insert PHP Docblock"
+      },
+      {
+        "command": "php-docblocker.re-parse",
+        "title": "Re-parse existing PHP Docblock"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "PHP DocBlocker configuration",

--- a/src/doc/selector.ts
+++ b/src/doc/selector.ts
@@ -1,0 +1,108 @@
+import {TextEditor, TextLine, Position, Range} from "vscode";
+
+/**
+ * Class for finding the start and end position of a docblock so it can be re-parseed
+ */
+export default class DocSelector
+{
+    /**
+     * Storage for the editor
+     *
+     * @type {TextEditor}
+     */
+    protected editor:TextEditor;
+
+    /**
+     * Construct the docblock with an editor so we can access text content
+     *
+     * @param {TextEditor} editor
+     */
+    public constructor(editor:TextEditor)
+    {
+        this.editor = editor;
+    }
+
+    /**
+     * Find the docblock within the area of search
+     *
+     * @param {Position|Range} position
+     * @returns {Range}
+     */
+    public find(position:Position): Range;
+    public find(position:Range): Range
+    public find(position): Range
+    {
+        let start:Position;
+        let end:Position;
+        if (position instanceof Range) {
+            start = position.start;
+            end = position.end;
+        } else if (position instanceof Position) {
+            start = position;
+            end = position;
+        }
+
+        let line = this.editor.document.lineAt(start.line);
+        if (!this.isStart(line) && !this.isMiddle(line) && !this.isEnd(line)) {
+            throw new Error("Unable to find docblock start");
+        }
+
+        while (!this.isStart(line)) {
+            if (line.lineNumber <= 1 || (!this.isMiddle(line) && !this.isEnd(line))) {
+                throw new Error("Unable to find docblock start");
+            }
+            line = this.editor.document.lineAt(line.lineNumber - 1);
+        }
+
+        start = new Position(line.lineNumber, line.firstNonWhitespaceCharacterIndex);
+
+        line = this.editor.document.lineAt(end.line);
+        if (!this.isStart(line) && !this.isMiddle(line) && !this.isEnd(line)) {
+            line = this.editor.document.lineAt(start.line);
+        }
+
+        while (!this.isEnd(line)) {
+            if (line.lineNumber >= this.editor.document.lineCount - 1 || (!this.isMiddle(line) && !this.isStart(line))) {
+                throw new Error("Unable to find docblock end");
+            }
+            line = this.editor.document.lineAt(line.lineNumber + 1);
+        }
+
+        end = line.range.end;
+
+        return new Range(start, end);
+    }
+
+    /**
+     * Is this line in the middle of a docblock
+     *
+     * @param {TextLine} line
+     * @returns {boolean}
+     */
+    protected isMiddle(line:TextLine):boolean
+    {
+        return line.text.search(/^\s*\*/) >= 0;
+    }
+
+    /**
+     * Is this line at the start of a docblock
+     *
+     * @param {TextLine} line
+     * @returns {boolean}
+     */
+    protected isStart(line:TextLine):boolean
+    {
+        return line.text.search(/^\s*\/\*\*?/) >= 0;
+    }
+
+    /**
+     * Is this line at the end of a docblock
+     *
+     * @param {TextLine} line
+     * @returns {boolean}
+     */
+    protected isEnd(line:TextLine):boolean
+    {
+        return line.text.search(/^\s*\*\//) >= 0;
+    }
+}

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -18,6 +18,13 @@ export default class Documenter
     protected targetPosition:Position;
 
     /**
+     * Capture the end position
+     *
+     * @type {Position}
+     */
+    protected targetEndPosition:Position;
+
+    /**
      * We'll need an editor to pass to each editor
      *
      * @type {TextEditor}
@@ -33,6 +40,7 @@ export default class Documenter
     public constructor(range:Range, editor:TextEditor)
     {
         this.targetPosition = range.start;
+        this.targetEndPosition = range.end;
         this.editor = editor;
     }
 
@@ -60,5 +68,27 @@ export default class Documenter
         }
 
         return new Doc().build(true);
+    }
+
+    /**
+     * Find an existing docblock and pass it's properties into a Doc object
+     */
+    public parseExisting():Doc
+    {
+        let line = this.targetPosition.line;
+        let part = this.editor.document.lineAt(line).text;
+        if (!part.search(/^\s*(\*|\/\*\*)/)) {
+            return null;
+        }
+
+        // Find the start position
+        while (!part.search(/^\s*\/\*\*\s*/) && line > 1) {
+            line--;
+            part = this.editor.document.lineAt(line).text;
+        }
+
+        console.log(part);
+
+        return new Doc();
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,49 +1,62 @@
-import * as vscode from 'vscode';
+import {commands, ExtensionContext, IndentAction, languages, Range, Selection, TextEditor} from 'vscode';
 import Completions from "./completions";
 import Documenter from './documenter';
+import DocSelector from './doc/selector';
 
 /**
  * Run a set up when the function is activated
  *
  * @param {vscode.ExtensionContext} context
  */
-export function activate(context: vscode.ExtensionContext)
+export function activate(context: ExtensionContext)
 {
     ['php', 'hack'].forEach(lang => {
         if (lang == 'hack') {
-            vscode.languages.setLanguageConfiguration(lang, {
+            languages.setLanguageConfiguration(lang, {
                 wordPattern: /(-?\d*\.\d\w*)|([^\-\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
                 onEnterRules: [
                     {
                         // e.g. /** | */
                         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
                         afterText: /^\s*\*\/$/,
-                        action: { indentAction: vscode.IndentAction.IndentOutdent, appendText: ' * ' }
+                        action: { indentAction: IndentAction.IndentOutdent, appendText: ' * ' }
                     }, {
                         // e.g. /** ...|
                         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
-                        action: { indentAction: vscode.IndentAction.None, appendText: ' * ' }
+                        action: { indentAction: IndentAction.None, appendText: ' * ' }
                     }, {
                         // e.g.  * ...|
                         beforeText: /^(\t|(\ \ ))*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
-                        action: { indentAction: vscode.IndentAction.None, appendText: '* ' }
+                        action: { indentAction: IndentAction.None, appendText: '* ' }
                     }, {
                         // e.g.  */|
                         beforeText: /^(\t|(\ \ ))*\ \*\/\s*$/,
-                        action: { indentAction: vscode.IndentAction.None, removeText: 1 }
+                        action: { indentAction: IndentAction.None, removeText: 1 }
                     }
                 ]
             });
         }
 
-        vscode.languages.registerCompletionItemProvider(lang, new Completions(), '*', '@');
+        languages.registerCompletionItemProvider(lang, new Completions(), '*', '@');
     });
 
-    vscode.commands.registerTextEditorCommand('php-docblocker.trigger', (textEditor:vscode.TextEditor) => {
-        textEditor.selection = new vscode.Selection(textEditor.selection.start, textEditor.selection.start);
-        let range = new vscode.Range(textEditor.selection.start, textEditor.selection.end);
+    commands.registerTextEditorCommand('php-docblocker.trigger', (textEditor:TextEditor) => {
+        textEditor.selection = new Selection(textEditor.selection.start, textEditor.selection.start);
+        let range = new Range(textEditor.selection.start, textEditor.selection.end);
         let documenter = new Documenter(range, textEditor);
         let snippet = documenter.autoDocument();
+        textEditor.insertSnippet(snippet);
+    });
+
+    commands.registerTextEditorCommand('php-docblocker.re-parse', (textEditor:TextEditor) => {
+        textEditor.selection = new Selection(textEditor.selection.start, textEditor.selection.start);
+        let range = new Range(textEditor.selection.start, textEditor.selection.end);
+        let documenter = new Documenter(range, textEditor);
+        let snippet = documenter.autoDocument();
+
+        let selector:DocSelector = new DocSelector(textEditor);
+        let existing:Range = selector.find(range);
+
         textEditor.insertSnippet(snippet);
     });
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -15,9 +15,16 @@ suite("Command tests", () => {
     });
 
     test("Command: trigger", () => {
-        editor.selection = new Selection(3, 0, 3, 0);
+        editor.selection = new Selection(2, 0, 2, 0);
         assert.doesNotThrow(async () => {
             await commands.executeCommand('php-docblocker.trigger', editor)
+        });
+    });
+
+    test("Command: re-parse", () => {
+        editor.selection = new Selection(7, 0, 7, 0);
+        assert.doesNotThrow(async () => {
+            await commands.executeCommand('php-docblocker.re-parse', editor)
         });
     });
 });

--- a/test/docselector.test.ts
+++ b/test/docselector.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert';
+import {TextDocument, TextEditor, Position, Range} from 'vscode';
+import Helper from './helpers';
+import DocSelector from '../src/doc/selector';
+
+suite("Docblock selector tests", () => {
+    let editor:TextEditor;
+    let document:TextDocument;
+    let selector:DocSelector;
+
+    suiteSetup(function(done) {
+        Helper.loadFixture('docs.php', (edit:TextEditor, doc:TextDocument) => {
+            editor = edit;
+            document = doc;
+            selector = new DocSelector(editor);
+            done();
+        });
+    });
+
+
+    let expected = new Range(new Position(2, 0), new Position(7, 3));
+    test("Find by start", () => {
+        assert.deepStrictEqual(selector.find(new Position(2, 0)), expected);
+        assert.deepStrictEqual(selector.find(new Position(2, 2)), expected);
+        assert.deepStrictEqual(selector.find(new Position(2, 3)), expected);
+    });
+
+    test("Find by middle", () => {
+        assert.deepStrictEqual(selector.find(new Position(3, 0)), expected);
+        assert.deepStrictEqual(selector.find(new Position(3, 2)), expected);
+        assert.deepStrictEqual(selector.find(new Position(4, 3)), expected);
+        assert.deepStrictEqual(selector.find(new Position(6, 10)), expected);
+    });
+
+    test("Find by end", () => {
+        assert.deepStrictEqual(selector.find(new Position(7, 0)), expected);
+        assert.deepStrictEqual(selector.find(new Position(7, 2)), expected);
+        assert.deepStrictEqual(selector.find(new Position(7, 3)), expected);
+    });
+});

--- a/test/fixtures/commands.php
+++ b/test/fixtures/commands.php
@@ -4,3 +4,7 @@
 class Trigger
 {
 }
+
+/**
+ *
+ */

--- a/test/fixtures/docs.php
+++ b/test/fixtures/docs.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Multiline message comment
+ *
+ * @param string $var
+ * @return string
+ */


### PR DESCRIPTION
This is the start of a change that will allow you to re-parse an existing docblock adding any missing params etc. This will be tricky because we could be parsing unknown configurations and trying to mix in.

Currently the status is I've got it detecting the range for an existing docblock. I'll move next onto splitting into tags and trying to merge with a new parse