### PR TITLE
Allow template order to be changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,29 +70,17 @@
         },
         "php-docblocker.functionTemplate": {
           "type": "object",
-          "default": {
-            "message": {},
-            "param": {},
-            "return": {},
-            "extra": {}
-          },
+          "default": null,
           "description": "Specify the default template for functions."
         },
         "php-docblocker.propertyTemplate": {
           "type": "object",
-          "default": {
-            "message": {},
-            "var": {},
-            "extra": {}
-          },
+          "default": null,
           "description": "Specify the default template for class variables."
         },
         "php-docblocker.classTemplate": {
           "type": "object",
-          "default": {
-            "message": {},
-            "extra": {}
-          },
+          "default": null,
           "description": "Specify the default template for classes."
         },
         "php-docblocker.author": {


### PR DESCRIPTION
Fixes #117 

Because when a default is provided it will take the order from that default and add properties of the keys so it means the order can't be changed. Setting to null fixes this and the default template in the getter of the doc should take over and provide the default behaviour.