### PR TITLE
Implement settings for aligning params and return statements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ This extension contributes the following settings:
 * `php-docblocker.returnVoid`: set to `false` to turn off the automatic void return type when it can't be determined
 * `php-docblocker.extra`: an array of extra tags to add to each DocBlock (These can include tabstops and snippet variables)
 * `php-docblocker.useShortNames`: Whether we should use short type names. e.g. bool or boolean
-* `php-docblocker.qualifyClassNames`: When adding type hints for class names search namespace use statements and qualify the class 
+* `php-docblocker.qualifyClassNames`: When adding type hints for class names search namespace use statements and qualify the class
+* `php-docblocker.alignParams`: set to `true` to align params vertically and add appropriate spaces after param names
+* `php-docblocker.alignReturn`: set to `true` to align return vertically with above params statements, this setting requires align params to also be active
 * `php-docblocker.author`: An object containing your default author tag settings
 * `php-docblocker.functionTemplate`: See below for how to set up docblock templates
 * `php-docblocker.propertyTemplate`: See below for how to set up docblock templates
@@ -74,7 +76,7 @@ config option per key to add additional control.
 
 #### Configured function template example
 
-In the example below we have added some gap configuration and removed the return tag for our template as well as 
+In the example below we have added some gap configuration and removed the return tag for our template as well as
 changing the default order. This means we'll never have a @return tag and extra comes before the params. It's also
 worth pointing out that the gapAfter in the message is the same as setting the gap config option in the main config
 to true.
@@ -93,8 +95,8 @@ to true.
 
 #### Configured function with extra content and placeholders
 
-The example below won't have a return tag and will add in an author tag with correct placeholders depending on 
-how many options you have. You can put in placeholders by using `###` in place of the tab stop number and it 
+The example below won't have a return tag and will add in an author tag with correct placeholders depending on
+how many options you have. You can put in placeholders by using `###` in place of the tab stop number and it
 will be calculated at generation time.
 
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-docblocker",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
           "default": false,
           "description": "Fully qualifies any data types used in param and returns by reading the namespaces."
         },
+        "php-docblocker.alignParams": {
+          "type": "boolean",
+          "default": false,
+          "description": "Vertically aligns param types and names with additional spaces."
+        },
+        "php-docblocker.alignReturn": {
+          "type": "boolean",
+          "default": false,
+          "description": "Vertically aligns return with above param statements."
+        },
         "php-docblocker.functionTemplate": {
           "type": "object",
           "default": null,

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -164,7 +164,9 @@ export class Doc
         if (this.return && (this.return != 'void' || Config.instance.get('returnVoid'))) {
             let appendSpace = '';
             if (alignReturn) {
-                appendSpace = Array(1 + maxParamNameLength).fill(' ').join('');
+                appendSpace =
+                    Array(1 + maxParamTypeLength - this.return.length).fill(' ').join('') +
+                    Array(maxParamNameLength).fill(' ').join('');
             }
             returnString = "@return \${###:" +this.return + "}" + appendSpace;
         }

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -109,7 +109,7 @@ export class Doc
         // Loop through params and find max length of type and name.
         let maxParamTypeLength = 0;
         let maxParamNameLength = 0;
-        if (this.params.length) {
+        if (this.params.length && alignParams) {
             this.params.forEach(param => {
                 let paramType = param.type;
                 if (paramType.length > maxParamTypeLength) {

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -325,5 +325,55 @@
             " * @param ${4:int} \\$name",
             " */"
         ]
+    },
+    {
+        "name": "Align params",
+        "config": {
+            "gap": true,
+            "alignParams": true
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$name",
+                    "type": "int"
+                }
+            ],
+            "return": "void"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @param ${2:int} \\$name",
+            " * @return ${3:void}",
+            " */"
+        ]
+    },
+    {
+        "name": "Align params and return statement",
+        "config": {
+            "gap": true,
+            "alignParams": true
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$name",
+                    "type": "int"
+                }
+            ],
+            "return": "void"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @param  ${2:int} \\$name ",
+            " * @return ${3:void}        ",
+            " */"
+        ]
     }
 ]

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -377,6 +377,10 @@
                 {
                     "name": "$nameEvenLonger",
                     "type": "LongClassName"
+                },
+                {
+                    "name": "$n",
+                    "type": "bool"
                 }
             ],
             "return": "void"
@@ -388,6 +392,7 @@
             " * @param ${2:int}           \\$nameLong       ",
             " * @param ${3:string}        \\$name           ",
             " * @param ${4:LongClassName} \\$nameEvenLonger ",
+            " * @param ${5:bool}          \\$n              ",
             " */"
         ]
     },

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -426,5 +426,36 @@
             " * @return ${4:LongClassName}           ",
             " */"
         ]
+    },
+    {
+        "name": "Align params and shorter return statement",
+        "config": {
+            "gap": true,
+            "alignParams": true,
+            "alignReturn": true
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$nameLong",
+                    "type": "int"
+                },
+                {
+                    "name": "$name",
+                    "type": "string"
+                }
+            ],
+            "return": "int"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @param  ${2:int}    \\$nameLong ",
+            " * @param  ${3:string} \\$name     ",
+            " * @return ${4:int}              ",
+            " */"
+        ]
     }
 ]

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -351,8 +351,8 @@
             " * ${1:Undocumented function}",
             " *",
             " * @param ${2:int}    \\$nameLong ",
-            " * @param ${2:string} \\$name     ",
-            " * @return ${3:LongClassName}",
+            " * @param ${3:string} \\$name     ",
+            " * @return ${4:LongClassName}",
             " */"
         ]
     },
@@ -382,7 +382,7 @@
             " * ${1:Undocumented function}",
             " *",
             " * @param ${2:int}    \\$nameLong ",
-            " * @param ${2:string} \\$name     ",
+            " * @param ${3:string} \\$name     ",
             " */"
         ]
     },
@@ -412,8 +412,8 @@
             " * ${1:Undocumented function}",
             " *",
             " * @param  ${2:int}           \\$nameLong ",
-            " * @param  ${2:string}        \\$name     ",
-            " * @return ${3:LongClassName}           ",
+            " * @param  ${3:string}        \\$name     ",
+            " * @return ${4:LongClassName}           ",
             " */"
         ]
     }

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -373,6 +373,10 @@
                 {
                     "name": "$name",
                     "type": "string"
+                },
+                {
+                    "name": "$nameEvenLonger",
+                    "type": "LongClassName"
                 }
             ],
             "return": "void"
@@ -381,8 +385,9 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int}    \\$nameLong ",
-            " * @param ${3:string} \\$name     ",
+            " * @param ${2:int}           \\$nameLong       ",
+            " * @param ${3:string}        \\$name           ",
+            " * @param ${4:LongClassName} \\$nameEvenLonger ",
             " */"
         ]
     },

--- a/test/fixtures/doc.json
+++ b/test/fixtures/doc.json
@@ -336,8 +336,43 @@
             "message": "Undocumented function",
             "params": [
                 {
-                    "name": "$name",
+                    "name": "$nameLong",
                     "type": "int"
+                },
+                {
+                    "name": "$name",
+                    "type": "string"
+                }
+            ],
+            "return": "LongClassName"
+        },
+        "expected": [
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @param ${2:int}    \\$nameLong ",
+            " * @param ${2:string} \\$name     ",
+            " * @return ${3:LongClassName}",
+            " */"
+        ]
+    },
+    {
+        "name": "Align params without return statement",
+        "config": {
+            "gap": true,
+            "alignParams": true,
+            "returnVoid": false
+        },
+        "input": {
+            "message": "Undocumented function",
+            "params": [
+                {
+                    "name": "$nameLong",
+                    "type": "int"
+                },
+                {
+                    "name": "$name",
+                    "type": "string"
                 }
             ],
             "return": "void"
@@ -346,8 +381,8 @@
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param ${2:int} \\$name",
-            " * @return ${3:void}",
+            " * @param ${2:int}    \\$nameLong ",
+            " * @param ${2:string} \\$name     ",
             " */"
         ]
     },
@@ -355,24 +390,30 @@
         "name": "Align params and return statement",
         "config": {
             "gap": true,
-            "alignParams": true
+            "alignParams": true,
+            "alignReturn": true
         },
         "input": {
             "message": "Undocumented function",
             "params": [
                 {
-                    "name": "$name",
+                    "name": "$nameLong",
                     "type": "int"
+                },
+                {
+                    "name": "$name",
+                    "type": "string"
                 }
             ],
-            "return": "void"
+            "return": "LongClassName"
         },
         "expected": [
             "/**",
             " * ${1:Undocumented function}",
             " *",
-            " * @param  ${2:int} \\$name ",
-            " * @return ${3:void}        ",
+            " * @param  ${2:int}           \\$nameLong ",
+            " * @param  ${2:string}        \\$name     ",
+            " * @return ${3:LongClassName}           ",
             " */"
         ]
     }


### PR DESCRIPTION
Related: #37 

Added 2 options:
- `php-docblocker.alignParams` , default `false`
- `php-docblocker.alignReturn` , default `false`

With alignParams: true
<img width="855" alt="Screenshot 2021-05-09 at 11 39 55" src="https://user-images.githubusercontent.com/8174945/117567206-5ec0d200-b0bb-11eb-9379-de93c4e4c6e9.png">

With alignParams: true and alignReturn: true
<img width="857" alt="Screenshot 2021-05-09 at 11 39 14" src="https://user-images.githubusercontent.com/8174945/117567214-6bddc100-b0bb-11eb-9a20-1873aefb52c0.png">


- The options are disabled to not affect existing users.
- The alignment is limited to spaces only.

<s>I was not able to run the test suite locally without issue, so I'm not quite sure how to write a tests to check for the new alignment. If you feel there is a need for additional tests, let me know and I'll see what I can do.</s>

I'm also very open for changes to code structure and naming conventions.