### PR TITLE
Added: php8 union types, constructor property AND param with default null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
+## [2.1.3] - 2021-05-24
+Patch By [tianyiw](https://github.com/tianyiw2013/vscode-php-docblocker). My English ability is very poor. Please forgive me if I have grammar mistakes.
+#### Added
+- **★ Support for PHP8 union types ★** [neild3r#150](https://github.com/neild3r/vscode-php-docblocker/issues/150)
+- **★ Support for PHP8 constructor property promotion ★** [neild3r#156](https://github.com/neild3r/vscode-php-docblocker/issues/156)
+- **★ Support for variable docblock ★**
+- Add param with default null [neild3r#140](https://github.com/neild3r/vscode-php-docblocker/issues/140)
+  - `int $num=null` to `@param int|null $num`
+  - `mixed $num=null` to `mixed $num`
+- Add option `autoIgnorePropertyType`: no `@var` is generated for the property of specified types`
+- Add option `unknownType`: You can choose `[type]` or `mixed`
+- Add option `defaultMessage`: You can choose `blank` `name`(function/class/var name) or `undocumented`(Undocumented function) [neild3r#139](https://github.com/neild3r/vscode-php-docblocker/issues/139)
+- Add option `variableTemplate`: Specify the default template for variables
+- Add option `variableInline`: If enabled, generated doc in a line. e.g. `/** @var mixed */` [neild3r#42](https://github.com/neild3r/vscode-php-docblocker/issues/42)
+- Add option `variableWithKey`: If enabled, generated document will contain a variable name. e.g. `@var mixed $name` [neild3r#106](https://github.com/neild3r/vscode-php-docblocker/issues/106)
+- Add tag `@mixin \MyClass` [neild3r#120](https://github.com/neild3r/vscode-php-docblocker/issues/120)
+- Add generate a PHP Attribute `#[Attribute]`
+- Improve the automatic detection of variable types. Such as `!1` `<<<EOF` `new class` `closure` `(string)` etc.
+- Compatibility with param syntax error, including php7.3 trailing comma [neild3r#153](https://github.com/neild3r/vscode-php-docblocker/issues/153)
+#### Fixed
+- After modifying the author config, you need to restart vscode to take effect. Now the change will take effect immediately.
+
 ## [2.1.0] - 2019-11-19
 - Add should to list of bool return type functions - Thanks @ImClarky
 - Fix issue where functions named with a bool return prefix were incorrectly given bool return type - Thanks @ImClarky
@@ -112,6 +134,7 @@ All notable changes to the "php-docblocker" extension will be documented in this
 - Initial release
 
 [Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.1.0...HEAD
+[2.1.3]: https://github.com/tianyiw2013/vscode-php-docblocker/releases/tag/2.1.3
 [2.1.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v1.9.0...v2.0.0

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ This extension contributes the following settings:
 * `php-docblocker.functionTemplate`: See below for how to set up docblock templates
 * `php-docblocker.propertyTemplate`: See below for how to set up docblock templates
 * `php-docblocker.classTemplate`: See below for how to set up docblock templates
+* `php-docblocker.autoIgnorePropertyTyp`: no `@var` is generated for the property of specified types`
+* `php-docblocker.unknownType`: You can choose `[type]` or `mixed`
+* `php-docblocker.defaultMessage`: You can choose `blank` `name`(function/class/var name) or `undocumented`(Undocumented function)
+* `php-docblocker.variableTemplate`: Specify the default template for variables
+* `php-docblocker.variableInline`: If enabled, generated doc in a line. e.g. `/** @var mixed */`
+* `php-docblocker.variableWithKey`: If enabled, generated document will contain a variable name. e.g. `@var mixed $name`
 
 ### Templating
 
@@ -152,6 +158,7 @@ and can be triggered by typing @ then another characted (Provided your vscode se
 | @link                        | @link ${1:http://url.com}               |
 | @medium                      | @medium                                 |
 | @method                      | @method ${1:mixed} ${2:methodName()}    |
+| @mixin                       | @mixin ${1:\Class}                      |
 | @package                     | @package ${1:category}                  |
 | @param                       | @param ${1:mixed} $${2:name}            |
 | @preserveGlobalState         | @preserveGlobalState                    |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "php-docblocker",
   "displayName": "PHP DocBlocker",
   "description": "A simple, dependency free PHP specific DocBlocking package",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "license": "MIT",
   "publisher": "neilbrayfield",
   "author": "Neil Brayfield <dev@brayfield.uk>",
@@ -41,6 +41,35 @@
       "type": "object",
       "title": "PHP DocBlocker configuration",
       "properties": {
+        "php-docblocker.autoIgnorePropertyType": {
+          "type": "boolean",
+          "default": false,
+          "description": "no `@var` is generated for the property of specified types`"
+        },
+        "php-docblocker.unknownType": {
+          "type": "string",
+          "default": "[type]",
+          "enum": [
+            "[type]",
+            "mixed"
+          ],
+          "description": "Placeholder of unknown type"
+        },
+        "php-docblocker.defaultMessage": {
+          "type": "string",
+          "default": "undocumented",
+          "enum": [
+            "blank",
+            "name",
+            "undocumented"
+          ],
+          "enumDescriptions": [
+            "blank",
+            "function/class/var name",
+            "e.g. Undocumented function"
+          ],
+          "description": "Document default message"
+        },
         "php-docblocker.gap": {
           "type": "boolean",
           "default": true,
@@ -85,6 +114,21 @@
           "type": "object",
           "default": null,
           "description": "Specify the default template for classes."
+        },
+        "php-docblocker.variableTemplate": {
+          "type": "object",
+          "default": null,
+          "description": "Specify the default template for variables."
+        },
+        "php-docblocker.variableInline": {
+          "type": "boolean",
+          "default": false,
+          "description": "If enabled, generated doc in a line. e.g. /** @var mixed */"
+        },
+        "php-docblocker.variableWithKey": {
+          "type": "boolean",
+          "default": false,
+          "description": "If enabled, generated document will contain a variable name. e.g. @var mixed $name"
         },
         "php-docblocker.author": {
           "type": "object",

--- a/src/block.ts
+++ b/src/block.ts
@@ -187,10 +187,8 @@ export abstract class Block
      */
     public getTypeFromValue(value:string):string
     {
-        let result:Array<string>;
-
         // Check for bool
-        if (value.match(/^\s*(false|true)\s*$/i) !== null) {
+        if (value.match(/^\s*(false|true)\s*$/i) !== null || value.match(/^\s*\!/i) !== null) {
             return TypeUtil.instance.getFormattedTypeByName('bool');
         }
 
@@ -205,7 +203,7 @@ export abstract class Block
         }
 
         // Check for string
-        if (value.match(/^\s*(["'])/) !== null) {
+        if (value.match(/^\s*(["'])/) !== null || value.match(/^\s*<<</) !== null) {
             return 'string';
         }
 
@@ -214,7 +212,28 @@ export abstract class Block
             return 'array';
         }
 
-        return '[type]';
+        // Check for class
+        var match = value.match(/^\s*new\s+([a-z0-9_\\\|]+)/i);
+        if (match) {
+            if (match[1] === 'class') {
+                return 'object';
+            }
+            return match[1];
+        }
+
+        // Check for closure
+        var match = value.match(/^\s*function\s*\(/i);
+        if (match) {
+            return '\\Closure';
+        }
+
+        // Check for type casting
+        var match = value.match(/^\s*\(\s*(int|integer|bool|boolean|float|double|real|string|array|object|unset)\s*\)/i);
+        if (match) {
+            return TypeUtil.instance.getFormattedTypeByName(match[1]);
+        }
+
+        return TypeUtil.instance.getUnknownType();
     }
 
     /**

--- a/src/block/class.ts
+++ b/src/block/class.ts
@@ -1,6 +1,7 @@
 import { Block } from "../block";
 import { Doc, Param } from "../doc";
 import Config from "../util/config";
+import TypeUtil from "../util/TypeUtil";
 
 /**
  * Represents a class block
@@ -18,7 +19,7 @@ export default class Class extends Block
     public parse():Doc
     {
         let params = this.match();
-        let doc = new Doc('Undocumented '+ params[2]);
+        let doc = new Doc(TypeUtil.instance.getDefaultMessage(params[3], params[2]));
         doc.template = Config.instance.get('classTemplate');
 
         return doc;

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -24,8 +24,7 @@ export default class FunctionBlock extends Block
     public parse():Doc
     {
         let params = this.match();
-
-        let doc = new Doc('Undocumented function');
+        let doc = new Doc(TypeUtil.instance.getDefaultMessage(params[5], 'function'));
         doc.template = Config.instance.get('functionTemplate');
         let argString = this.getEnclosed(params[6], "(", ")");
         let head:string;
@@ -42,15 +41,20 @@ export default class FunctionBlock extends Block
                 let arg = args[index];
                 let parts = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([a-z0-9_\|\\]+)?\s*\&?((?:[.]{3})?\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                 if (parts === null) {
+                    // trailing comma
+                    if (arg.trim() === '') {
+                        continue;
+                    }
                     // compatibility syntax error
                     parts = arg.match(/^.*?(\?)?\s*([a-z0-9_\|\\]+)\s*(\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                     if (parts === null) {
-                        console.error('Match parameter of failure: ', arg);
-                        parts = [arg, null, arg.trim(), '', ''];
+                        // console.error('Match parameter of failure: ', arg);
+                        // parts = [arg, null, arg.trim(), '', '']; # bug: array $options=[1,2]
+                        continue;
                     }
                 }
                 
-                var type = '[type]';
+                var type = TypeUtil.instance.getUnknownType();
 
                 if (parts[2] != null) {
                     parts[2] = TypeUtil.instance.getFullyQualifiedType(parts[2], head);

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -49,6 +49,8 @@ export default class FunctionBlock extends Block
 
                 if (parts[2] != null && parts[1] === '?') {
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
+                } else if (parts[2] != null && parts[1] === undefined && parts[4] === "null") {// int $var = null
+                    type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
                 } else if (parts[2] != null) {
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2]);
                 } else if (parts[4] != null && parts[4] != "") {

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -59,7 +59,7 @@ export default class FunctionBlock extends Block
             }
         }
 
-        let returnType:Array<string> = this.signature.match(/.*\)\s*\:\s*(\?)?\s*([a-zA-Z_0-9\\]+)\s*$/m);
+        let returnType:Array<string> = this.signature.match(/.*\)\s*\:\s*(\?)?\s*([a-zA-Z_0-9\|\\]+)\s*$/m);
 
         if (returnType != null) {
             if (Config.instance.get('qualifyClassNames')) {

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -40,7 +40,16 @@ export default class FunctionBlock extends Block
 
             for (let index = 0; index < args.length; index++) {
                 let arg = args[index];
-                let parts = arg.match(/^\s*(\?)?\s*([A-Za-z0-9_\\]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
+                let parts = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([a-z0-9_\\]+)?\s*\&?((?:[.]{3})?\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
+                if (parts === null) {
+                    // compatibility syntax error
+                    parts = arg.match(/^.*?(\?)?\s*([a-z0-9_\\]+)\s*(\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
+                    if (parts === null) {
+                        console.error('Match parameter of failure: ', arg);
+                        continue;
+                    }
+                }
+                
                 var type = '[type]';
 
                 if (parts[2] != null) {

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -40,10 +40,10 @@ export default class FunctionBlock extends Block
 
             for (let index = 0; index < args.length; index++) {
                 let arg = args[index];
-                let parts = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([a-z0-9_\\]+)?\s*\&?((?:[.]{3})?\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
+                let parts = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([a-z0-9_\|\\]+)?\s*\&?((?:[.]{3})?\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                 if (parts === null) {
                     // compatibility syntax error
-                    parts = arg.match(/^.*?(\?)?\s*([a-z0-9_\\]+)\s*(\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
+                    parts = arg.match(/^.*?(\?)?\s*([a-z0-9_\|\\]+)\s*(\$[a-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                     if (parts === null) {
                         console.error('Match parameter of failure: ', arg);
                         parts = [arg, null, arg.trim(), '', ''];
@@ -57,9 +57,9 @@ export default class FunctionBlock extends Block
                 }
 
                 if (parts[2] != null && parts[1] === '?') {
-                    type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
+                    type = TypeUtil.instance.getFormattedTypeByName(parts[2], true);
                 } else if (parts[2] != null && parts[2] != "mixed" && parts[1] === undefined && parts[4] === "null") {// int $var = null
-                    type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
+                    type = TypeUtil.instance.getFormattedTypeByName(parts[2], true);
                 } else if (parts[2] != null) {
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2]);
                 } else if (parts[4] != null && parts[4] != "") {

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -49,7 +49,7 @@ export default class FunctionBlock extends Block
 
                 if (parts[2] != null && parts[1] === '?') {
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
-                } else if (parts[2] != null && parts[1] === undefined && parts[4] === "null") {// int $var = null
+                } else if (parts[2] != null && parts[2] != "mixed" && parts[1] === undefined && parts[4] === "null") {// int $var = null
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2])+'|null';
                 } else if (parts[2] != null) {
                     type = TypeUtil.instance.getFormattedTypeByName(parts[2]);

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -46,7 +46,7 @@ export default class FunctionBlock extends Block
                     parts = arg.match(/^.*?(\?)?\s*([a-z0-9_\\]+)\s*(\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/m);
                     if (parts === null) {
                         console.error('Match parameter of failure: ', arg);
-                        continue;
+                        parts = [arg, null, arg.trim(), '', ''];
                     }
                 }
                 

--- a/src/block/property.ts
+++ b/src/block/property.ts
@@ -1,6 +1,7 @@
 import { Block } from "../block";
 import { Doc, Param } from "../doc";
 import Config from "../util/config";
+import TypeUtil from "../util/TypeUtil";
 
 /**
  * Represents an property block
@@ -11,7 +12,7 @@ export default class Property extends Block
     /**
      * @inheritdoc
      */
-    protected pattern:RegExp = /^\s*(static)?\s*(protected|private|public)\s+(static)?\s*(\$[A-Za-z0-9_]+)\s*\=?\s*([^;]*)/m;
+    protected pattern:RegExp = /^\s*(protected|private|public|static)\s+([a-z0-9_\?\|\\\s]+)?\s*(\$[a-z0-9_]+)\s*\=?\s*([^;]*)/im;
 
     /**
      * @inheritdoc
@@ -19,16 +20,31 @@ export default class Property extends Block
     public parse():Doc
     {
         let params = this.match();
-
-        let doc = new Doc('Undocumented variable');
-        doc.template = Config.instance.get('propertyTemplate');
-
-        if (params[5]) {
-            doc.var = this.getTypeFromValue(params[5]);
-        } else {
-            doc.var = '[type]';
+        
+        let type = params[2] ? String(params[2]).trim().split(/\s+/).pop() : false;
+        if (type && ['protected', 'private', 'public', 'static'].indexOf(type.toLowerCase()) !== -1) {
+            type = false;
         }
 
+        let doc = new Doc(TypeUtil.instance.getDefaultMessage(String(params[3]).substr(1), 'property'));
+        doc.template = Config.instance.get('propertyTemplate');
+
+        if (type) {
+            let nullable = params[4] === 'null';
+            if (type.charAt(0) === '?') {
+                nullable = true;
+                type = type.substr(1);
+            }
+            doc.var = TypeUtil.instance.getFormattedTypeByName(type, nullable);
+        } else if (params[4]) {
+            doc.var = this.getTypeFromValue(params[4]);
+        } else {
+            doc.var = TypeUtil.instance.getUnknownType();
+        }
+
+        if (type && Config.instance.get('autoIgnorePropertyType')) {
+            doc.var = undefined;
+        }
         return doc;
     }
 }

--- a/src/block/variable.ts
+++ b/src/block/variable.ts
@@ -1,0 +1,42 @@
+import { Block } from "../block";
+import { Doc, Param } from "../doc";
+import Config from "../util/config";
+import TypeUtil from "../util/TypeUtil";
+
+/**
+ * Represents an var block
+ */
+export default class Variable extends Block
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected pattern:RegExp = /^\s*(\$[a-z0-9_]+)\s*\=?\s*([^;]*)/im;
+
+    /**
+     * @inheritdoc
+     */
+    public parse():Doc
+    {
+        let params = this.match();
+        let doc = new Doc(TypeUtil.instance.getDefaultMessage(String(params[1]).substr(1), 'variable'));
+        doc.template = Config.instance.get('variableTemplate');
+
+        if (params[2]) {
+            doc.var = this.getTypeFromValue(params[2]);
+        } else {
+            doc.var = TypeUtil.instance.getUnknownType();
+        }
+        if (Config.instance.get('variableWithKey')) {
+            doc.var += ' ' + params[1];
+        }
+
+        doc.inline = Config.instance.get('variableInline');
+        if (doc.inline) {
+            doc.message = '';
+        }
+
+        return doc;
+    }
+}

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -38,6 +38,13 @@ export class Doc
     public message:string;
 
     /**
+     * Doc inline
+     *
+     * @type {boolean}
+     */
+    public inline:boolean = false;
+
+    /**
      * Define the template for the documentor
      *
      * @type {Object}
@@ -69,6 +76,9 @@ export class Doc
         }
         if (input.message !== undefined) {
             this.message = input.message;
+        }
+        if (input.inline !== undefined) {
+            this.inline = input.inline;
         }
         if (input.params !== undefined && Array.isArray(input.params)) {
             input.params.forEach(param => {
@@ -114,7 +124,14 @@ export class Doc
         }
 
         if (this.var) {
-            varString = "@var \${###:" +this.var + "}";
+            // @var type $name
+            varString = "@var";
+            let vars = this.var.split(' ');
+            for (let index = 0; index < vars.length; index++) {
+                if (vars[index] !== '') {
+                    varString += " \${###:" + vars[index].replace('$', '\\$') + "}";
+                }
+            }
         }
 
         if (this.return && (this.return != 'void' || Config.instance.get('returnVoid'))) {
@@ -167,8 +184,14 @@ export class Doc
             templateArray.pop();
         }
 
-        let templateString:string = templateArray.join("\n");
-        templateString = "/**\n" + templateString + "\n */";
+        let templateString:string;
+
+        if (this.inline && templateArray.length === 3) {
+            templateString = "/** " + templateArray[2] + " " + templateArray[0] + " */";
+        } else {
+            templateString = templateArray.join("\n");
+            templateString = "/**\n" + templateString + "\n */";
+        }
 
         let stop = 0;
         templateString = templateString.replace(/###/gm, function():string {

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -3,6 +3,7 @@ import FunctionBlock from "./block/function";
 import Property from "./block/property";
 import Class from "./block/class";
 import {Doc, Param} from "./doc";
+import Variable from "./block/Variable";
 
 /**
  * Check which type of docblock we need and instruct the components to build the
@@ -57,6 +58,11 @@ export default class Documenter
         let cla = new Class(this.targetPosition, this.editor);
         if (cla.test()) {
             return cla.parse().build();
+        }
+
+        let variable = new Variable(this.targetPosition, this.editor);
+        if (variable.test()) {
+            return variable.parse().build();
         }
 
         return new Doc().build(true);

--- a/src/util/TypeUtil.ts
+++ b/src/util/TypeUtil.ts
@@ -57,24 +57,41 @@ export default class TypeUtil {
      * Returns the user configuration based name for the given type
      *
      * @param {string} name
+     * @param {boolean} nullable
      */
-    public getFormattedTypeByName(name:string) {
-        switch (name) {
-            case 'bool':
-            case 'boolean':
-                if (!Config.instance.get('useShortNames')) {
-                    return 'boolean';
-                }
-                return 'bool';
-            case 'int':
-            case 'integer':
-                if (!Config.instance.get('useShortNames')) {
-                    return 'integer';
-                }
-                return 'int';
-            default:
-                return name;
+    public getFormattedTypeByName(name:string, nullable:boolean=false) {
+        let result = [];
+        let names = name.split("|");
+        for (let index = 0; index < names.length; index++) {
+            switch (names[index]) {
+                case '':
+                    continue;
+                case 'bool':
+                case 'boolean':
+                    if (Config.instance.get('useShortNames')) {
+                        names[index] = 'bool';
+                    } else {
+                        names[index] = 'boolean';
+                    }
+                    break;
+                case 'int':
+                case 'integer':
+                    if (Config.instance.get('useShortNames')) {
+                        names[index] = 'int';
+                    } else {
+                        names[index] = 'integer';
+                    }
+                    break;
+            }
+            result.push(names[index]);
         }
+        if (result.length === 0) {
+            result.push('mixed');
+        }
+        if (nullable && result.indexOf('null') === -1) {
+            result.push('null');
+        }
+        return result.join('|');
     }
 
 }

--- a/src/util/TypeUtil.ts
+++ b/src/util/TypeUtil.ts
@@ -66,6 +66,13 @@ export default class TypeUtil {
             switch (names[index]) {
                 case '':
                     continue;
+                case 'real':
+                case 'double':
+                    names[index] = 'float';
+                    break;
+                case 'unset':
+                    names[index] = 'null';
+                    break;
                 case 'bool':
                 case 'boolean':
                     if (Config.instance.get('useShortNames')) {
@@ -94,4 +101,28 @@ export default class TypeUtil {
         return result.join('|');
     }
 
+    /**
+     * Unknown type
+     * 
+     * @returns {stirng} `[type]` or `mixed`
+     */
+    public getUnknownType():string {
+        return Config.instance.get('unknownType');
+    }
+
+    /**
+     * Default message
+     * 
+     * @param {string} defaultMessage 
+     */
+    public getDefaultMessage(name:string, type:string): string {
+        switch (Config.instance.get('defaultMessage')) {
+            case 'name':
+                return name;
+            case 'blank':
+                return '';
+            default:
+                return "Undocumented " + type;
+        }
+    }
 }

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -21,6 +21,9 @@ suite("Class tests", () => {
     });
 
     map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
         test("Match Test: "+ testData.name, () => {
             let func = new Class(testPositions[testData.key], editor);
             assert.equal(func.test(), true, test.name);
@@ -30,5 +33,17 @@ suite("Class tests", () => {
             let func = new Class(testPositions[testData.key], editor);
             assert.ok(func.parse(), test.name);
         });
+
+        if (testData.result) {
+            test("Type Test: "+ testData.name, () => {
+                Helper.setConfig(testData.config);
+                let prop = new Class(testPositions[testData.key], editor);
+                let actual:Doc = prop.parse();
+                let expected:Doc = new Doc('Undocumented class');
+                expected.fromObject(testData.result);
+                expected.template = Helper.getConfig().get('classTemplate');
+                assert.deepEqual(actual, expected);
+            }); 
+        }
     });
 });

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -21,6 +21,9 @@ suite("Completion tests", () => {
     });
 
     map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
         test("Completion: "+ testData.name, () => {
             let pos:Position = testPositions[testData.key];
             let result:any = completions.provideCompletionItems(

--- a/test/doc.test.ts
+++ b/test/doc.test.ts
@@ -8,6 +8,9 @@ suite("Snippet build tests", () => {
     let map = Helper.getFixtureMap('doc.json');
 
     map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
         test("Snippet test: "+ testData.name, () => {
             let doc = new Doc();
             let empty = false;

--- a/test/fixtures/classes.php
+++ b/test/fixtures/classes.php
@@ -83,3 +83,12 @@ class ImplementedSubClass extends App\Model\ImplementedParentClass implements Ap
 {
 
 }
+
+////=> default-message-blank
+class default_message_blank{}
+
+////=> default-message-name
+class default_message_name{}
+
+////=> default-message-undocumented
+class default_message_undocumented{}

--- a/test/fixtures/classes.php.json
+++ b/test/fixtures/classes.php.json
@@ -50,5 +50,32 @@
     {
         "key": "extends-implements-namespace",
         "name": "Implement and implmentes classes with a namespaces"
+    },
+    {
+        "key": "default-message-blank",
+        "config": {
+            "defaultMessage": "blank"
+        },
+        "result": {
+            "message": ""
+        }
+    },
+    {
+        "key": "default-message-name",
+        "config": {
+            "defaultMessage": "name"
+        },
+        "result": {
+            "message": "default_message_name"
+        }
+    },
+    {
+        "key": "default-message-undocumented",
+        "config": {
+            "defaultMessage": "undocumented"
+        },
+        "result": {
+            "message": "Undocumented class"
+        }
     }
 ]

--- a/test/fixtures/completions.php
+++ b/test/fixtures/completions.php
@@ -19,6 +19,10 @@
  /**
  protected $name;
 
+////=> variable
+ /**
+ $name = null;
+
 ////=> function
  /**
  protected function name()
@@ -33,3 +37,6 @@
 
  ////=> empty
  /**
+
+////=> attribute
+#

--- a/test/fixtures/completions.php.json
+++ b/test/fixtures/completions.php.json
@@ -55,10 +55,23 @@
         ]
     },
     {
+        "key": "variable",
+        "name": "variable trigger",
+        "result": [
+            "/**"
+        ]
+    },
+    {
         "key": "empty",
         "name": "Empty trigger",
         "result": [
             "/**"
+        ]
+    },
+    {
+        "key": "attribute",
+        "result": [
+            "#[Attribute]"
         ]
     }
 ]

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -23,7 +23,7 @@ abstract class Test
     }
 
     ////=> compatibility-syntax-error
-    function compatibilitySyntaxError(syntax error int $arg)
+    function compatibilitySyntaxError(syntax error int $arg, syntax error, syntax_error)
     {
     }
 

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -101,6 +101,11 @@ abstract class Test
     {
     }
 
+    ////=> param-mixed-default-null
+    public function paramMixedDefaultNull(mixed $arg = null)
+    {
+    }
+
     ////=> args
     public function dotArgs(...$args) {
     }

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -176,8 +176,18 @@ abstract class Test
     {
     }
 
-    ////=> php8-union-types
-    public function getPHP8UnionTypes():int|bool|\TypeHint|App\Model\TypeHint
+    ////=> php8-return-union-types
+    public function getPHP8ReturnUnionTypes():int|bool|\TypeHint|App\Model\TypeHint
+    {
+    }
+
+    ////=> php8-return-union-types-with-short-name
+    public function getPHP8ReturnUnionTypesShortName():int|bool|\TypeHint|App\Model\TypeHint
+    {
+    }
+
+    ////=> php8-param-union-types
+    public function getPHP8ParamUnionTypes(int|bool|\TypeHint|App\Model\TypeHint $arg, string|\Closure ...$args)
     {
     }
 

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -23,7 +23,7 @@ abstract class Test
     }
 
     ////=> compatibility-syntax-error
-    function compatibilitySyntaxError(syntax error int $arg, syntax error, syntax_error)
+    function compatibilitySyntaxError(syntax error int $arg, syntax error, syntax_error, int| $arg1, || $arg2)
     {
     }
 

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -23,7 +23,7 @@ abstract class Test
     }
 
     ////=> compatibility-syntax-error
-    function compatibilitySyntaxError(syntax error int $arg, syntax error, syntax_error, int| $arg1, || $arg2)
+    function compatibilitySyntaxError(syntax error int $arg,, syntax error, syntax_error, int| $arg1, || $arg2,)
     {
     }
 
@@ -288,6 +288,21 @@ abstract class Test
 
     ////=> to-string
     public function __toString()
+    {
+    }
+
+    ////=> default-message-blank
+    public function default_message_blank()
+    {
+    }
+
+    ////=> default-message-name
+    public function default_message_name()
+    {
+    }
+
+    ////=> default-message-undocumented
+    public function default_message_undocumented()
     {
     }
 }

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -96,6 +96,11 @@ abstract class Test
     {
     }
 
+    ////=> param-default-null
+    public function paramDefaultNull(int $arg = null)
+    {
+    }
+
     ////=> args
     public function dotArgs(...$args) {
     }
@@ -153,6 +158,11 @@ abstract class Test
 
     ////=> php7-return-namespace-full
     public function getPHP7ReturnNamespaceFull():App\Model\TypeHint
+    {
+    }
+
+    ////=> php8-union-types
+    public function getPHP8UnionTypes():int|bool|\TypeHint|App\Model\TypeHint
     {
     }
 

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -17,6 +17,16 @@ abstract class Test
     {
     }
 
+    ////=> php8-constructor-with-property
+    function __construct(public $arg1, protected int $arg2, PriVate ?int $arg3)
+    {
+    }
+
+    ////=> compatibility-syntax-error
+    function compatibilitySyntaxError(syntax error int $arg)
+    {
+    }
+
     ////=> abstract-simple
     abstract public function getName();
 

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -273,6 +273,19 @@
         }
     },
     {
+        "key": "param-mixed-default-null",
+        "name": "Param with mixed and default null",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$arg",
+                    "type": "mixed"
+                }
+            ]
+        }
+    },
+    {
         "key": "args",
         "name": "Argument with ...$args",
         "result": {

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -24,6 +24,40 @@
         }
     },
     {
+        "key": "php8-constructor-with-property",
+        "name": "php8 Constructor with property",
+        "result": {
+            "return": null,
+            "params": [
+                {
+                    "name": "$arg1",
+                    "type": "[type]"
+                },
+                {
+                    "name": "$arg2",
+                    "type": "int"
+                },
+                {
+                    "name": "$arg3",
+                    "type": "int|null"
+                }
+            ]
+        }
+    },
+    {
+        "key": "compatibility-syntax-error",
+        "name": "compatibility with param syntax error",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$arg",
+                    "type": "int"
+                }
+            ]
+        }
+    },
+    {
         "key": "abstract-simple",
         "name": "Abstract method simple",
         "result": {

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -55,14 +55,6 @@
                     "type": "integer"
                 },
                 {
-                    "name": "",
-                    "type": "syntax error"
-                },
-                {
-                    "name": "",
-                    "type": "syntax_error"
-                },
-                {
                     "name": "$arg1",
                     "type": "integer"
                 },
@@ -705,6 +697,36 @@
                     "type": "[type]"
                 }
             ]
+        }
+    },
+    {
+        "key": "default-message-blank",
+        "config": {
+            "defaultMessage": "blank"
+        },
+        "result": {
+            "return": "void",
+            "message": ""
+        }
+    },
+    {
+        "key": "default-message-name",
+        "config": {
+            "defaultMessage": "name"
+        },
+        "result": {
+            "return": "void",
+            "message": "default_message_name"
+        }
+    },
+    {
+        "key": "default-message-undocumented",
+        "config": {
+            "defaultMessage": "undocumented"
+        },
+        "result": {
+            "return": "void",
+            "message": "Undocumented function"
         }
     }
 ]

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -35,11 +35,11 @@
                 },
                 {
                     "name": "$arg2",
-                    "type": "int"
+                    "type": "integer"
                 },
                 {
                     "name": "$arg3",
-                    "type": "int|null"
+                    "type": "integer|null"
                 }
             ]
         }
@@ -52,7 +52,15 @@
             "params": [
                 {
                     "name": "$arg",
-                    "type": "int"
+                    "type": "integer"
+                },
+                {
+                    "name": "",
+                    "type": "syntax error"
+                },
+                {
+                    "name": "",
+                    "type": "syntax_error"
                 }
             ]
         }

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -413,11 +413,42 @@
         }
     },
     {
-        "key": "php8-union-types",
-        "name": "PHP8 union types",
+        "key": "php8-return-union-types",
+        "name": "PHP8 return union types",
+        "result": {
+            "return": "integer|boolean|\\TypeHint|App\\Model\\TypeHint",
+            "params": []
+        }
+    },
+    {
+        "key": "php8-return-union-types-with-short-name",
+        "name": "PHP8 return union types with short-name",
+        "config": {
+            "useShortNames": true
+        },
         "result": {
             "return": "int|bool|\\TypeHint|App\\Model\\TypeHint",
             "params": []
+        }
+    },
+    {
+        "key": "php7-return-param",
+        "name": "PHP7 return type with param",
+        "config": {
+            "useShortNames": true
+        },
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$arg",
+                    "type": "int|bool|\\TypeHint|App\\Model\\TypeHint"
+                },
+                {
+                    "name": "...$args",
+                    "type": "string|\\Closure"
+                }
+            ]
         }
     },
     {

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -432,8 +432,8 @@
         }
     },
     {
-        "key": "php7-return-param",
-        "name": "PHP7 return type with param",
+        "key": "php8-param-union-types",
+        "name": "PHP8 param union types",
         "config": {
             "useShortNames": true
         },

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -260,6 +260,19 @@
         }
     },
     {
+        "key": "param-default-null",
+        "name": "Param with default null",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$arg",
+                    "type": "integer|null"
+                }
+            ]
+        }
+    },
+    {
         "key": "args",
         "name": "Argument with ...$args",
         "result": {
@@ -341,6 +354,14 @@
         "name": "PHP7 return namespace type",
         "result": {
             "return": "App\\Model\\TypeHint",
+            "params": []
+        }
+    },
+    {
+        "key": "php8-union-types",
+        "name": "PHP8 union types",
+        "result": {
+            "return": "int|bool|\\TypeHint|App\\Model\\TypeHint",
             "params": []
         }
     },

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -61,6 +61,14 @@
                 {
                     "name": "",
                     "type": "syntax_error"
+                },
+                {
+                    "name": "$arg1",
+                    "type": "integer"
+                },
+                {
+                    "name": "$arg2",
+                    "type": "mixed"
                 }
             ]
         }

--- a/test/fixtures/properties.php
+++ b/test/fixtures/properties.php
@@ -9,10 +9,16 @@ abstract class Test
     protected $protected;
 
     ////=> static
+    static $static;
+
+    ////=> protected-static
     protected static $static;
 
     ////=> static-alternate
     static protected $staticAlt;
+
+    ////=> ignore-case
+    STatiC ProtecteD $ignoreCase;
 
     ////=> default-string
     protected $defaultString = 'string';
@@ -54,4 +60,38 @@ abstract class Test
 
     ////=> default-null
     public $defaultNull = null;
+
+    ////=> specify-type
+    protected array $specifyType;
+
+    ////=> union-types
+    protected array|string $unionTypes;
+
+    ////=> string-with-null
+    protected ?string $stringWithNull;
+
+    ////=> string-default-null
+    protected string $stringDefaultNull = null;
+
+    ////=> syntax-error
+    protected syntax error string $stringDefaultNull = null;
+
+    ////=> auto-ignore-property-type
+    protected string|int $autoIgnorePropertyType;
+
+    ////=> auto-ignore-property-type-mixed
+    protected $autoIgnorePropertyTypeMixed;
+
+    ////=> auto-ignore-property-type-withtype
+    protected $autoIgnorePropertyTypeWithtype;
+
+    ////=> default-message-blank
+    protected $default_message_blank;
+
+    ////=> default-message-name
+    protected $default_message_name;
+
+    ////=> default-message-undocumented
+    protected $default_message_undocumented;
+
 }

--- a/test/fixtures/properties.php.json
+++ b/test/fixtures/properties.php.json
@@ -2,76 +2,200 @@
     {
         "key": "public",
         "name": "Public",
-        "var": "[type]"
+        "result": {
+            "var": "[type]"
+        }
     },
     {
         "key": "protected",
         "name": "Protected",
-        "var": "[type]"
+        "result": {
+            "var": "[type]"
+        }
     },
     {
         "key": "static",
-        "name": "Static",
-        "var": "[type]"
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "protected-static",
+        "result": {
+            "var": "[type]"
+        }
     },
     {
         "key": "static-alternate",
         "name": "Static Alternate",
-        "var": "[type]"
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "ignore-case",
+        "result": {
+            "var": "[type]"
+        }
     },
     {
         "key": "default-string",
         "name": "Default String",
-        "var": "string"
+        "result": {
+            "var": "string"
+        }
     },
     {
         "key": "default-string-alternate",
         "name": "Default String Alternate",
-        "var": "string"
+        "result": {
+            "var": "string"
+        }
     },
     {
         "key": "default-bool",
         "name": "Default Bool",
-        "var": "boolean"
+        "result": {
+            "var": "boolean"
+        }
     },
     {
         "key": "default-bool-alternate",
         "name": "Default Bool Alternate",
-        "var": "boolean"
+        "result": {
+            "var": "boolean"
+        }
     },
     {
         "key": "default-array",
         "name": "Default Array",
-        "var": "array"
+        "result": {
+            "var": "array"
+        }
     },
     {
         "key": "default-array-alternate",
         "name": "Default Array Alternate",
-        "var": "array"
+        "result": {
+            "var": "array"
+        }
     },
     {
         "key": "multiline",
         "name": "Multiline",
-        "var": "array"
+        "result": {
+            "var": "array"
+        }
     },
     {
         "key": "multiline-alternate",
         "name": "Multiline Alternate",
-        "var": "array"
+        "result": {
+            "var": "array"
+        }
     },
     {
         "key": "default-float",
         "name": "Default Float",
-        "var": "float"
+        "result": {
+            "var": "float"
+        }
     },
     {
         "key": "default-int",
         "name": "Default Int",
-        "var": "integer"
+        "result": {
+            "var": "integer"
+        }
     },
     {
         "key": "default-null",
         "name": "Default Null",
-        "var": "[type]"
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "specify-type",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "union-types",
+        "result": {
+            "var": "array|string"
+        }
+    },
+    {
+        "key": "string-with-null",
+        "result": {
+            "var": "string|null"
+        }
+    },
+    {
+        "key": "string-default-null",
+        "result": {
+            "var": "string|null"
+        }
+    },
+    {
+        "key": "syntax-error",
+        "result": {
+            "var": "string|null"
+        }
+    },
+    {
+        "key": "auto-ignore-property-type",
+        "config": {
+            "autoIgnorePropertyType": true
+        },
+        "result": {}
+    },
+    {
+        "key": "auto-ignore-property-type-mixed",
+        "config": {
+            "autoIgnorePropertyType": true,
+            "unknownType": "mixed"
+        },
+        "result": {
+            "var": "mixed"
+        }
+    },
+    {
+        "key": "auto-ignore-property-type-withtype",
+        "config": {
+            "autoIgnorePropertyType": true
+        },
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "default-message-blank",
+        "config": {
+            "defaultMessage": "blank"
+        },
+        "result": {
+            "message": ""
+        }
+    },
+    {
+        "key": "default-message-name",
+        "config": {
+            "defaultMessage": "name"
+        },
+        "result": {
+            "message": "default_message_name"
+        }
+    },
+    {
+        "key": "default-message-undocumented",
+        "config": {
+            "defaultMessage": "undocumented"
+        },
+        "result": {
+            "message": "Undocumented property"
+        }
     }
 ]

--- a/test/fixtures/variables.php
+++ b/test/fixtures/variables.php
@@ -1,0 +1,95 @@
+<?php
+
+////=> float1
+$var = .3;
+
+////=> float2
+$var = 0.3;
+
+////=> int1
+$var = 3;
+
+////=> int2
+$var = 03;
+
+////=> bool1
+$var = true;
+
+////=> bool2
+$var = !0;
+
+////=> bool3
+$var = !'test';
+
+////=> stdclass
+$var = new stdClass;
+
+////=> object
+$var = new class {};
+
+////=> string1
+$var = 'string';
+
+////=> string2
+$var = "string";
+
+////=> string3
+$var = <<<EOF
+string
+EOF;
+
+////=> closure
+$var = function () {};
+
+////=> array1
+$var = [1,2,3];
+
+////=> array2
+$var = [];
+
+////=> array3
+$var = array(
+    1
+);
+
+////=> array4
+$var = [
+    1
+];
+
+////=> type-casting-string
+$var = (string)1;
+
+////=> type-casting-float1
+$var = (float)1;
+
+////=> type-casting-float2
+$var = (real)1;
+
+////=> type-casting-float3
+$var = (double)1;
+
+////=> type-casting-null
+$var = (unset)1;
+
+////=> mixed1
+$var = test();
+
+////=> mixed2
+$var = null;
+
+////=> default-message-blank
+$default_message_blank = 1;
+
+////=> default-message-name
+$default_message_name = 1;
+
+////=> default-message-undocumented
+$default_message_undocumented = 1;
+
+////=> inline
+$inline = 1;
+
+////=> inline-with-key
+$inline = 1;
+

--- a/test/fixtures/variables.php.json
+++ b/test/fixtures/variables.php.json
@@ -1,0 +1,198 @@
+[
+    {
+        "key": "float1",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "float2",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "int1",
+        "result": {
+            "var": "integer"
+        }
+    },
+    {
+        "key": "int2",
+        "result": {
+            "var": "integer"
+        }
+    },
+    {
+        "key": "bool1",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "bool2",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "bool3",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "stdclass",
+        "result": {
+            "var": "stdClass"
+        }
+    },
+    {
+        "key": "object",
+        "result": {
+            "var": "object"
+        }
+    },
+    {
+        "key": "string1",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "string2",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "string3",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "closure",
+        "result": {
+            "var": "\\Closure"
+        }
+    },
+    {
+        "key": "array2",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array2",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array3",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array4",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "type-casting-string",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "type-casting-float1",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-float2",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-float3",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-null",
+        "result": {
+            "var": "null"
+        }
+    },
+    {
+        "key": "mixed1",
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "mixed2",
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "default-message-blank",
+        "config": {
+            "defaultMessage": "blank"
+        },
+        "result": {
+            "message": ""
+        }
+    },
+    {
+        "key": "default-message-name",
+        "config": {
+            "defaultMessage": "name"
+        },
+        "result": {
+            "message": "default_message_name"
+        }
+    },
+    {
+        "key": "default-message-undocumented",
+        "config": {
+            "defaultMessage": "undocumented"
+        },
+        "result": {
+            "message": "Undocumented variable"
+        }
+    },
+    {
+        "key": "inline",
+        "config": {
+            "variableInline": true
+        },
+        "result": {
+            "inline": true,
+            "message": "",
+            "var": "integer"
+        },
+        "doc": "/** @var ${1:integer} ${2} */"
+    },
+    {
+        "key": "inline-with-key",
+        "config": {
+            "variableInline": true,
+            "variableWithKey": true
+        },
+        "result": {
+            "inline": true,
+            "message": "",
+            "var": "integer $inline"
+        },
+        "doc": "/** @var ${1:integer} ${2:\\$inline} ${3} */"
+    }
+]

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -23,6 +23,9 @@ suite("Function tests", () => {
     });
 
     map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
         test("Match Test: "+ testData.name, () => {
             let func = new Function(testPositions[testData.key], editor);
             assert.equal(func.test(), true, test.name);

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -1,19 +1,18 @@
 import * as assert from 'assert';
 import {TextEditor, TextDocument} from 'vscode';
 import Helper from './helpers';
-import Function from '../src/block/property';
 import {Doc, Param} from '../src/doc';
-import Property from '../src/block/property';
+import Variable from '../src/block/Variable';
 
-suite("Property tests", () => {
+suite("Variable tests", () => {
     let editor:TextEditor;
     let document:TextDocument;
     let testPositions:any = {};
 
-    let map = Helper.getFixtureMap('properties.php.json');
+    let map = Helper.getFixtureMap('variables.php.json');
 
     suiteSetup(function(done) {
-        Helper.loadFixture('properties.php', (edit:TextEditor, doc:TextDocument) => {
+        Helper.loadFixture('variables.php', (edit:TextEditor, doc:TextDocument) => {
             editor = edit;
             document = doc;
             testPositions = Helper.getFixturePositions(document);
@@ -27,27 +26,31 @@ suite("Property tests", () => {
         }
         
         test("Match Test: "+ testData.name, () => {
-            let prop = new Property(testPositions[testData.key], editor);
-            assert.equal(prop.test(), true, test.name);
+            let variable = new Variable(testPositions[testData.key], editor);
+            assert.equal(variable.test(), true, test.name);
         });
 
         test("Parse Test: "+ testData.name, () => {
-            let prop = new Property(testPositions[testData.key], editor);
-            assert.ok(prop.parse(), test.name);
+            let variable = new Variable(testPositions[testData.key], editor);
+            assert.ok(variable.parse(), test.name);
         });
 
         test("Type Test: "+ testData.name, () => {
             Helper.setConfig(testData.config);
-            let prop = new Property(testPositions[testData.key], editor);
-            let actual:Doc = prop.parse();
-            let expected:Doc = new Doc('Undocumented property');
-            if (testData.result.var ===undefined) {
+            let variable = new Variable(testPositions[testData.key], editor);
+            let actual:Doc = variable.parse();
+            let expected:Doc = new Doc('Undocumented variable');
+            if (testData.result.var === undefined) {
                 expected.var = undefined;
             }
             expected.fromObject(actual);
             expected.fromObject(testData.result);
-            expected.template = Helper.getConfig().get('propertyTemplate');
+            expected.template = Helper.getConfig().get('variableTemplate');
             assert.deepEqual(actual, expected);
+
+            if (testData.doc !== undefined) {
+                assert.equal(actual.build().value, testData.doc, test.name);
+            }
         });
     });
 });


### PR DESCRIPTION
## php8 Union types #150 

```php
/**
 * PHP8 union types
 * 
 * @param int|bool $arg
 * @return int|bool
 */
function getPHP8UnionTypes(int|bool $arg): int|bool
{
}
```

## php8 Constructor with property #156 
```php
  /**
   * php8 Constructor with property
   *
   * @param [type] $arg1
   * @param int $arg2
   * @param int|null $arg3
   */
  function __construct(public $arg1, protected int $arg2, PriVate ?int $arg3)
  {
  }
```

##  Param with default null
```php
/**
 * Param with default null
 *
 * @param int|null $arg
 * @return void
 */
function paramDefaultNull(int $arg = null)
{
}

/**
 * Param with mixed and default null
 *
 * @param mixed $arg
 * @return void
 */
function paramMixedDefaultNull(mixed $arg = null)
{
}
```

## compatibility with param syntax error
```php
  /**
   * compatibility with param syntax error
   *
   * @param int $arg
   * @param syntax error 
   * @param syntax_error 
   * @param int $arg2
   * @param mixed $arg3
   * @return void
   */
  function compatibilitySyntaxError(syntax error int $arg, syntax error, syntax_error, int| $arg2, || $arg3)
  {
  }
```