### PR TITLE
Add support for php 7.4 typed properties

### DIFF
--- a/src/block/property.ts
+++ b/src/block/property.ts
@@ -1,6 +1,7 @@
 import { Block } from "../block";
 import { Doc, Param } from "../doc";
 import Config from "../util/config";
+import TypeUtil from "../util/TypeUtil";
 
 /**
  * Represents an property block
@@ -11,7 +12,7 @@ export default class Property extends Block
     /**
      * @inheritdoc
      */
-    protected pattern:RegExp = /^\s*(static)?\s*(protected|private|public)\s+(static)?\s*(\$[A-Za-z0-9_]+)\s*\=?\s*([^;]*)/m;
+    protected pattern:RegExp = /^\s*(static)?\s*(protected|private|public)\s+(static)?\s*(\??\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\]+)?\s*(\$[A-Za-z0-9_]+)\s*\=?\s*([^;]*)/m;
 
     /**
      * @inheritdoc
@@ -23,8 +24,24 @@ export default class Property extends Block
         let doc = new Doc('Undocumented variable');
         doc.template = Config.instance.get('propertyTemplate');
 
-        if (params[5]) {
-            doc.var = this.getTypeFromValue(params[5]);
+        if (params[4]) {
+            let parts:Array<string> = params[4].match(/(\?)?(.*)/m);
+            let head:string;
+
+            if (Config.instance.get('qualifyClassNames')) {
+                head = this.getClassHead();
+            }
+
+            let varType = TypeUtil.instance.getFullyQualifiedType(parts[2], head);
+            varType = TypeUtil.instance.getFormattedTypeByName(varType);
+
+            if (parts[1] === '?') {
+                varType += '|null';
+            }
+
+            doc.var = varType;
+        } else if (params[6]) {
+            doc.var = this.getTypeFromValue(params[6]);
         } else {
             doc.var = '[type]';
         }

--- a/test/fixtures/properties.php
+++ b/test/fixtures/properties.php
@@ -54,4 +54,31 @@ abstract class Test
 
     ////=> default-null
     public $defaultNull = null;
+
+    ////=> typed-string
+    public string $typedString;
+
+    ////=> typed-int
+    public int $typedInt;
+
+    ////=> typed-interface
+    public DateTimeInterface $typedInterface;
+
+    ////=> typed-namespace
+    public \App\Type\Test $typedNamespace;
+
+    ////=> typed-string-default
+    public string $typedStringDefault = 'test';
+
+    ////=> typed-int-default
+    public int $typedIntDefault = 42;
+
+    ////=> typed-string-nullable
+    public ?string $typedStringNullable;
+
+    ////=> typed-interface-nullable
+    public ?DateTimeInterface $typedInterfaceNullable;
+
+    ////=> typed-namespace-nullable
+    public ?\App\Type\Test $typedNamespaceNullable;
 }

--- a/test/fixtures/properties.php.json
+++ b/test/fixtures/properties.php.json
@@ -73,5 +73,50 @@
         "key": "default-null",
         "name": "Default Null",
         "var": "[type]"
+    },
+    {
+        "key": "typed-string",
+        "name": "Typed string",
+        "var": "string"
+    },
+    {
+        "key": "typed-int",
+        "name": "Typed Int",
+        "var": "integer"
+    },
+    {
+        "key": "typed-interface",
+        "name": "Typed Interface",
+        "var": "DateTimeInterface"
+    },
+    {
+        "key": "typed-namespace",
+        "name": "Typed namespace",
+        "var": "\\App\\Type\\Test"
+    },
+    {
+        "key": "typed-string-default",
+        "name": "Typed string with default",
+        "var": "string"
+    },
+    {
+        "key": "typed-int-default",
+        "name": "Typed Int with default",
+        "var": "integer"
+    },
+    {
+        "key": "typed-string-nullable",
+        "name": "Nullable typed string",
+        "var": "string|null"
+    },
+    {
+        "key": "typed-interface-nullable",
+        "name": "Nullable typed inteface",
+        "var": "DateTimeInterface|null"
+    },
+    {
+        "key": "typed-namespace-nullable",
+        "name": "Nullable typed namespace",
+        "var": "\\App\\Type\\Test|null"
     }
 ]

--- a/test/fixtures/properties.php.json
+++ b/test/fixtures/properties.php.json
@@ -117,6 +117,9 @@
     {
         "key": "typed-namespace-nullable",
         "name": "Nullable typed namespace",
-        "var": "\\App\\Type\\Test|null"
+        "var": "\\App\\Type\\Test|null",
+        "config": {
+            "qualifyClassNames": true
+        }
     }
 ]


### PR DESCRIPTION
Apologies this has been so long delayed I've been very busy both personally and professionally and I haven't been using 7.4 much.

Here it is though support for types and nullable types in class properties.