### PR TITLE
Improve `getClassHead` error tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+- Improve class head tolerance when there isn't one or it's too long
+- Increased class head limit to 300 lines
 
 ## [2.6.0] - 2021-09-27
 

--- a/src/block.ts
+++ b/src/block.ts
@@ -212,15 +212,21 @@ export abstract class Block
      *
      * @returns {string}
      */
-    public getClassHead():string
+    public getClassHead(): string
     {
         if (this.classHead === undefined) {
-            let text = this.editor.document.getText(new Range(new Position(0, 0), new Position(150,0)));
+            let limit = this.editor.document.lineCount < 300 ? this.editor.document.lineCount - 1 : 300;
+            let text = this.editor.document.getText(new Range(new Position(0, 0), new Position(limit, 0)));
             let regex = /\s*(abstract|final)?\s*(class|trait|interface)/gm;
             let match = regex.exec(text);
-            let end = this.editor.document.positionAt(match.index);
-            let range = new Range(new Position(0, 0), end);
-            this.classHead = this.editor.document.getText(range);
+
+            if (match === null) {
+                this.classHead = null;
+            } else {
+                let end = this.editor.document.positionAt(match.index);
+                let range = new Range(new Position(0, 0), end);
+                this.classHead = this.editor.document.getText(range);
+            }
         }
 
         return this.classHead;

--- a/test/TypeUtil.test.ts
+++ b/test/TypeUtil.test.ts
@@ -75,3 +75,27 @@ suite("TypeUtil tests: ", () => {
     });
 
 });
+
+suite("TypeUtil issue test: ", () => {
+    let editor:TextEditor;
+
+    suiteSetup(function(done) {
+        workspace.openTextDocument(Helper.fixturePath+'namespace-issue.php').then(doc => {
+            window.showTextDocument(doc).then(textEditor => {
+                editor = textEditor;
+                done();
+            }, error => {
+                console.log(error);
+            })
+        }, error => {
+            console.log(error);
+        });
+    });
+
+    test("Ensure class head does not fail if there isn't one", () => {
+        let block = new FunctionBlock(new Position(0, 0), editor);
+        let head = block.getClassHead();
+
+        assert.equal(head, null);
+    });
+});

--- a/test/fixtures/namespace-issue.php
+++ b/test/fixtures/namespace-issue.php
@@ -1,0 +1,7 @@
+<?php
+
+
+
+function testNoNamespace() {
+
+}


### PR DESCRIPTION
**Change Summary**:
When you have class name qualification on and you try to DocBlock outside of a class the function errors. SImilarly if you have a class head greater than 150 lines long it also causes a problem.

Upped the head limit to 300 and made failures less catastrophic.

Fixes #208
Fixes #207 

**Checks**:
* [x] `CHANGELOG.md` updated with relavent changes
