### PR TITLE
v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+
+## [2.6.1] - 2021-10-12
 - Fix double start delimeter when vscode setting `editor.autoClosingBrackets` is set to `never`
 - Improve class head tolerance when there isn't one or it's too long
 - Increased class head limit to 300 lines
@@ -166,7 +168,8 @@ All notable changes to the "php-docblocker" extension will be documented in this
 ## 0.1.0 - 2017-03-12
 - Initial release
 
-[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/neild3r/vscode-php-docblocker/compare/v2.3.0...v2.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "php-docblocker",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "php-docblocker",
   "displayName": "PHP DocBlocker",
   "description": "A simple, dependency free PHP specific DocBlocking package",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "MIT",
   "publisher": "neilbrayfield",
   "author": "Neil Brayfield <dev@brayfield.uk>",


### PR DESCRIPTION
- Fix double start delimeter when vscode setting `editor.autoClosingBrackets` is set to `never`
- Improve class head tolerance when there isn't one or it's too long
- Increased class head limit to 300 lines