### PR TITLE
Fix full class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+- Fixed fully qualifies class namespace detection can be incorrect with _ [#214](https://github.com/neild3r/vscode-php-docblocker/issues/214)
+- Supported fully qualifies class namespace use with bracket `use some\namespace\{ ClassA, ClassB, ... }`
+- Supported fully qualifies class namespace use with comma `use some\namespace\ClassA, some\namespace\ClassB, ...`
 
 ## [2.6.1] - 2021-10-12
 - Fix double start delimeter when vscode setting `editor.autoClosingBrackets` is set to `never`

--- a/src/util/TypeUtil.ts
+++ b/src/util/TypeUtil.ts
@@ -71,10 +71,11 @@ export default class TypeUtil {
             let prefix: string;
             let with_bracket = value.indexOf('{') !== -1;
             if (with_bracket) {
+                value += '}'; // fault-tolerant
                 let bracket_begin = value.indexOf('{');
                 let bracket_end = value.indexOf('}');
                 prefix = value.substring(0, bracket_begin).trim();
-                classes = value.substring(bracket_begin + 1, bracket_end === -1 ? undefined : bracket_end).split(',');
+                classes = value.substring(bracket_begin + 1, bracket_end).split(',');
             } else {
                 prefix = '';
                 classes = value.split(',');
@@ -87,10 +88,7 @@ export default class TypeUtil {
                 }
                 value = prefix + value;
                 let [clazz, alias] = value.split(/\s+as\s+/gmi, 2);
-                if (!clazz) {
-                    continue;
-                }
-                if (alias === undefined && clazz.endsWith('\\' + type)) {
+                if (!alias && clazz.endsWith('\\' + type)) {
                     // aa\bb
                 } else if (alias === type) {
                     // aa\bb as cc

--- a/test/TypeUtil.test.ts
+++ b/test/TypeUtil.test.ts
@@ -23,6 +23,14 @@ suite("TypeUtil tests: ", () => {
         });
     });
 
+    test("Test the classes returned from use is correct", () => {
+        let type = new TypeUtil;
+        assert.deepEqual(type.getClassesFromUse('ClassA'), { 'ClassA': 'ClassA' });
+        assert.deepEqual(type.getClassesFromUse('ClassB as B'), { 'B': 'ClassB' });
+        assert.deepEqual(type.getClassesFromUse('ClassA, namespace\\ClassB as B'), { 'ClassA': 'ClassA', 'B': 'namespace\\ClassB' });
+        assert.deepEqual(type.getClassesFromUse('namespace\\{ ClassA, ClassB as B }'), { 'ClassA': 'namespace\\ClassA', 'B': 'namespace\\ClassB' });
+    });
+
     test("Ensure typehint is not mismatched", () => {
         let type = new TypeUtil;
         Helper.setConfig({qualifyClassNames: true});

--- a/test/TypeUtil.test.ts
+++ b/test/TypeUtil.test.ts
@@ -47,6 +47,48 @@ suite("TypeUtil tests: ", () => {
         assert.equal(type.getFullyQualifiedType('BaseExample', head), '\\App\\Test\\Model\\Example');
     });
 
+    test("Fully qualify typehint from namespace use with _", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('ExampleInterface', head), '\\App\\Example\\ExampleInterface');
+    });
+
+    test("Fully qualify typehint from namespace use with bracket", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('ClassA', head), '\\some\\namespace\\ClassA');
+    });
+
+    test("Fully qualify typehint from namespace use with bracket+alias", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('ClassB_alias', head), '\\some\\namespace\\ClassB');
+    });
+
+    test("Fully qualify typehint from namespace use with comma", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('ClassD', head), '\\some\\namespace\\ClassD');
+    });
+
+    test("Fully qualify typehint from namespace use with comma+alias", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('ClassE_alias', head), '\\some\\namespace\\ClassE');
+    });
+
+    test("Fully qualify typehint from namespace use const", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('myconst', head), 'myconst');
+    });
+
+    test("Fully qualify typehint from namespace use function", () => {
+        let type = new TypeUtil;
+        Helper.setConfig({qualifyClassNames: true});
+        assert.equal(type.getFullyQualifiedType('myfunction', head), 'myfunction');
+    });
+
     test("With default settings the integer type formatted is integer", () => {
         let type = new TypeUtil;
         assert.equal(type.getFormattedTypeByName('int'), 'integer');

--- a/test/fixtures/namespace.php
+++ b/test/fixtures/namespace.php
@@ -12,6 +12,19 @@ use \Monolog\Handler\StreamHandler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\InvalidArgumentException;
 
+use Example_ExampleInterface;
+use App\Example\ExampleInterface;
+
+use some\namespace\{
+    ClassA,
+    ClassB as ClassB_alias,
+};
+use some\namespace\ClassD,
+    some\namespace\ClassE as ClassE_alias;
+
+use const some\namespace\myconst;
+use function some\namespace\myfunction;
+
 /**
  * Example class here
  */


### PR DESCRIPTION
**Change Summary**:
- Fixed fully qualifies class namespace detection can be incorrect with _ #214 
- Supported fully qualifies class namespace use with bracket `use some\namespace\{ ClassA, ClassB, ... }` #122 
- Supported fully qualifies class namespace use with comma `use some\namespace\ClassA, some\namespace\ClassB, ...`

**Checks**:
* [x] `CHANGELOG.md` updated with relavent changes
