### PR TITLE
PHP 8.1 Readonly Properties AND  Intersection Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+- Supported PHP 8.1 Readonly Properties
+- Supported PHP 8.1 Intersection Types
 
 ## [2.6.1] - 2021-10-12
 - Fix double start delimeter when vscode setting `editor.autoClosingBrackets` is set to `never`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to the "php-docblocker" extension will be documented in this
 - Supported PHP 8.1 Readonly Properties
 - Supported PHP 8.1 Intersection Types
 
-
 ## [2.6.1] - 2021-10-12
 - Fix double start delimeter when vscode setting `editor.autoClosingBrackets` is set to `never`
 - Improve class head tolerance when there isn't one or it's too long

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -40,7 +40,7 @@ export default class FunctionBlock extends Block
 
             for (let index = 0; index < args.length; index++) {
                 let arg:string = args[index];
-                let parts:string[] = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([A-Za-z0-9|_\\]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/im);
+                let parts:string[] = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([A-Za-z0-9_\\][A-Za-z0-9_\\|&]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                 var type:string = '[type]';
 
                 if (parts[2] != null) {

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -41,7 +41,7 @@ export default class FunctionBlock extends Block
             for (let index = 0; index < args.length; index++) {
                 let arg:string = args[index];
                 let parts:string[] = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(?:readonly\s+)?(\?)?\s*([A-Za-z0-9_\\][A-Za-z0-9_\\|&]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/im);
-                var type:string = '[type]';
+                var type:string = TypeUtil.instance.getDefaultType();
 
                 if (parts[2] != null) {
                     type = TypeUtil.instance.getResolvedTypeHints(parts[2], head);

--- a/src/block/function.ts
+++ b/src/block/function.ts
@@ -40,7 +40,7 @@ export default class FunctionBlock extends Block
 
             for (let index = 0; index < args.length; index++) {
                 let arg:string = args[index];
-                let parts:string[] = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(\?)?\s*([A-Za-z0-9_\\][A-Za-z0-9_\\|&]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/im);
+                let parts:string[] = arg.match(/^\s*(?:(?:public|protected|private)\s+)?(?:readonly\s+)?(\?)?\s*([A-Za-z0-9_\\][A-Za-z0-9_\\|&]+)?\s*\&?((?:[.]{3})?\$[A-Za-z0-9_]+)\s*\=?\s*(.*)\s*/im);
                 var type:string = '[type]';
 
                 if (parts[2] != null) {

--- a/src/block/property.ts
+++ b/src/block/property.ts
@@ -12,7 +12,7 @@ export default class Property extends Block
     /**
      * @inheritdoc
      */
-    protected pattern:RegExp = /^\s*(static)?\s*(protected|private|public)\s+(static)?\s*(\??\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9|_\x7f-\xff\\]+)?\s*(\$[A-Za-z0-9_]+)\s*\=?\s*([^;]*)/m;
+    protected pattern:RegExp = /^\s*(static)?\s*(protected|private|public)\s+(static\s*)?(?:readonly\s*)?(\??\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9|_\x7f-\xff\\]+)?\s*(\$[A-Za-z0-9_]+)\s*\=?\s*([^;]*)/m;
 
     /**
      * @inheritdoc

--- a/src/util/TypeUtil.ts
+++ b/src/util/TypeUtil.ts
@@ -30,14 +30,18 @@ export default class TypeUtil {
      */
     public getResolvedTypeHints(types:string, head:string = null): string
     {
-        let union:string[] = types.split("|");
-        
-        for (let index = 0; index < union.length; index++) {
+        let union:string[] = types.split(/([|&])/);
+        for (let index = 0; index < union.length; index += 2) {
+            if (union[index] === '') {
+                delete union[index];
+                delete union[index+1];
+                continue;
+            }
             union[index] = this.getFullyQualifiedType(union[index], head);
             union[index] = this.getFormattedTypeByName(union[index]);
         }
 
-        return union.join("|");
+        return union.join('');
     }
 
     /**

--- a/test/fixtures/functions.php
+++ b/test/fixtures/functions.php
@@ -202,6 +202,16 @@ abstract class Test
     ) {
     }
 
+    ////=> php81-intersection-types
+    function intersection_types(Iterator&\Countable $var)
+    {
+    }
+
+    ////=> php81-union-intersection-types-fault-tolerant
+    function union_intersection_types_fault_tolerant(Iterator&\Countable|Aaa||&|&Bbb &$var)
+    {
+    }
+
     ////=> function-reference
     public function &someFunction()
     {

--- a/test/fixtures/functions.php.json
+++ b/test/fixtures/functions.php.json
@@ -486,6 +486,32 @@
         }
     },
     {
+        "key": "php81-intersection-types",
+        "name": "PHP8.1 intersection types",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$var",
+                    "type": "Iterator&\\Countable"
+                }
+            ]
+        }
+    },
+    {
+        "key": "php81-union-intersection-types-fault-tolerant",
+        "name": "PHP8.1 unionin types AND tersection types with fault-tolerant",
+        "result": {
+            "return": "void",
+            "params": [
+                {
+                    "name": "$var",
+                    "type": "Iterator&\\Countable|Aaa|Bbb"
+                }
+            ]
+        }
+    },
+    {
         "key": "function-reference",
         "name": "Function with reference ampersand",
         "result": {

--- a/test/fixtures/properties.php
+++ b/test/fixtures/properties.php
@@ -91,4 +91,7 @@ abstract class Test
 
     ////=> union-type-nullable
     public string|array|null $unionTypeNullable;
+
+    ////=> readonly
+    public readonly string $readonly;
 }

--- a/test/fixtures/properties.php.json
+++ b/test/fixtures/properties.php.json
@@ -141,5 +141,10 @@
         "key": "union-type-nullable",
         "name": "PHP8 union type that can be null",
         "var": "string|array|null"
+    },
+    {
+        "key": "readonly",
+        "name": "PHP8.1 readonly",
+        "var": "string"
     }
 ]


### PR DESCRIPTION
**Change Summary**:
- Supported PHP 8.1 Readonly Properties
- Supported PHP 8.1 Intersection Types

**Checks**:
* [x] `CHANGELOG.md` updated with relavent changes
