### PR TITLE
Provide environment variables in configuration settings if present in…

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -238,8 +238,16 @@ export class Doc
             templateString = "/**\n" + templateString + "\n */";
         }
 
-        let snippet = new SnippetString(templateString);
+        // Replace environment variables.
+        const envReg = new RegExp('(?!=\$\{env:)([^}]+)(?!=})', 'g');
+        if (templateString.match(envReg) !== null) {
+            let matches = templateString.match(envReg);
+            matches.forEach(envVar => {
+                templateString = templateString.replace('${env:' + envVar + '}', Config.instance.get(envVar));
+            });
+        }
 
+        let snippet = new SnippetString(templateString);
         return snippet;
     }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -76,8 +76,12 @@ export default class Config {
         if (this.isLive) {
             if (setting === "autoClosingBrackets") {
                 return workspace.getConfiguration('editor').get(setting);
+            } else if (setting.indexOf('env:') > 0) {
+                const key = setting.replace('env:', '');
+                if (process.env.hasOwnProperty(key)) {
+                    return process.env[key];
+                }
             }
-
             return workspace.getConfiguration('php-docblocker').get(setting);
         }
 


### PR DESCRIPTION
… process.env

**Change Summary**:
*[ What have you changed and why? ]*

I have changed the extension to allow user configurations to include `${env:myVariable}` in tag content definitions which will be replaced with environment variables available to the extension at runtime using `process.env`. This will be useful for automatic inclusion of a PHP project's version number which can be more easily automated as an environment variable than it can as a VS Code setting. Without this change I have to manually input the project's current version number for `@since` and `@version` tags. This also allows me to define more tag content at the User-level such as `@copyright` and `@package` by setting it to `${env:PACKAGE_NAME}` and ensuring the directory provides this environment variable before VS Code starts.

**Checks**:
* [ ] `CHANGELOG.md` updated with relevant changes
