### PR TITLE
Supported variable docblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the "php-docblocker" extension will be documented in this file.
 
 ## [Unreleased]
+- Supported variable docblock
+```php
+# Example
+
+/** @var int $var  */
+$var = 1;
+
+/** @var stdClass $object  */
+$object = new stdClass;
+
+/** @var \Closure $callback  */
+$callback = function () {};
+$callback = fn () => 1;
+
+/** @var [type] $item  */
+foreach ($data as $item) {}
+
+/** @var [type] $item  */
+while ($item = array_pop($data)) {}
+```
 
 ## [2.7.0] - 2022-02-11
 - Allow configuration of default type

--- a/src/block/ForeachBlock.ts
+++ b/src/block/ForeachBlock.ts
@@ -1,0 +1,24 @@
+import { Doc, Param } from "../doc";
+import VariableBlock from "./VariableBlock";
+
+/**
+ * Represents an var block for `foreach`
+ */
+export default class ForeachBlock extends VariableBlock
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected pattern:RegExp = /^\s*foreach\s*\(.*?as\s+(\$[a-z_][a-z0-9_]*\s*=>\s*)?(\$[a-z_][a-z0-9_]*)\s*\)/im;
+
+    /**
+     * @inheritdoc
+     */
+    public parse():Doc
+    {
+        let params = this.match();
+        return this.parseVar(params[2]);
+    }
+}
+

--- a/src/block/VariableBlock.ts
+++ b/src/block/VariableBlock.ts
@@ -1,0 +1,46 @@
+import { Block } from "../block";
+import { Doc, Param } from "../doc";
+import Config from "../util/config";
+import TypeUtil from "../util/TypeUtil";
+
+/**
+ * Represents an var block
+ */
+export default class VariableBlock extends Block
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected pattern:RegExp = /^\s*(\$[a-z0-9_]+)\s*\=?\s*([^;]*)/im;
+
+    /**
+     * @inheritdoc
+     */
+    public parse():Doc
+    {
+        let params = this.match();
+        return this.parseVar(params[1], params[2]);
+    }
+    
+    /**
+     * parse
+     * 
+     * @param key e.g.`$key`
+     * @param value
+     * @returns 
+     */
+    protected parseVar(key: string, value: any=undefined): Doc
+    {
+        let doc = new Doc(key.substring(1));
+        if (value) {
+            doc.var = TypeUtil.instance.getTypeFromValue(value);
+        } else {
+            doc.var = TypeUtil.instance.getDefaultType();
+        }
+        doc.inline = true;
+
+        return doc;
+    }
+}
+

--- a/src/block/WhileBlock.ts
+++ b/src/block/WhileBlock.ts
@@ -1,0 +1,24 @@
+import { Doc, Param } from "../doc";
+import VariableBlock from "./VariableBlock";
+
+/**
+ * Represents an var block for `while`
+ */
+export default class WhileBlock extends VariableBlock
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected pattern:RegExp = /^\s*while\s*\((\$[a-z0-9_]+)\s*=(?!=)/im;
+
+    /**
+     * @inheritdoc
+     */
+    public parse():Doc
+    {
+        let params = this.match();
+        return this.parseVar(params[1]);
+    }
+}
+

--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -3,6 +3,9 @@ import FunctionBlock from "./block/function";
 import Property from "./block/property";
 import Class from "./block/class";
 import {Doc, Param} from "./doc";
+import VariableBlock from "./block/VariableBlock";
+import ForeachBlock from "./block/ForeachBlock";
+import WhileBlock from "./block/WhileBlock";
 
 /**
  * Check which type of docblock we need and instruct the components to build the
@@ -57,6 +60,21 @@ export default class Documenter
         let cla = new Class(this.targetPosition, this.editor);
         if (cla.test()) {
             return cla.parse().build();
+        }
+
+        let variable = new VariableBlock(this.targetPosition, this.editor);
+        if (variable.test()) {
+            return variable.parse().build();
+        }
+
+        let foreach = new ForeachBlock(this.targetPosition, this.editor);
+        if (foreach.test()) {
+            return foreach.parse().build();
+        }
+
+        let while_ = new WhileBlock(this.targetPosition, this.editor);
+        if (while_.test()) {
+            return while_.parse().build();
         }
 
         return new Doc().build(true);

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -21,6 +21,9 @@ suite("Completion tests", () => {
     });
 
     map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
         test("Completion: " + testData.name, () => {
             let pos:Position = testPositions[testData.key];
             let result:any = completions.provideCompletionItems(
@@ -31,10 +34,12 @@ suite("Completion tests", () => {
 
             let matched:Array<string> = [];
             result.forEach(data => {
-                matched.push(data.label);
+                matched.push(data.insertText.value);
             });
+            let actual = matched.join("\n");
+            let expected = testData.result.join("\n");
 
-            assert.deepEqual(testData.result, matched);
+            assert.deepEqual(actual, expected);
         });
     });
 });

--- a/test/fixtures/completions.php
+++ b/test/fixtures/completions.php
@@ -31,5 +31,25 @@
  {
  }
 
+////=> variable
+ /**
+ $var = null;
+
+////=> foreach
+ /**
+ foreach ([] as $key => $value) {
+
+////=> foreach-with-key
+ /**
+ foreach ([] as $value) {
+
+////=> while
+ /**
+ while ($value = array_shift($arrs)) {
+
+////=> while-no-var
+ /**
+ while ($value == true) {
+
  ////=> empty
  /**

--- a/test/fixtures/completions.php.json
+++ b/test/fixtures/completions.php.json
@@ -3,28 +3,28 @@
         "key": "param",
         "name": "Param tag",
         "result": [
-            "@param"
+            "@param ${1:mixed} $${2:name}"
         ]
     },
     {
         "key": "return",
         "name": "Return tag",
         "result": [
-            "@return"
+            "@return ${1:mixed}"
         ]
     },
     {
         "key": "package",
         "name": "Package tag",
         "result": [
-            "@package"
+            "@package ${1:category}"
         ]
     },
     {
         "key": "var",
         "name": "Var tag",
         "result": [
-            "@var"
+            "@var ${1:mixed}"
         ]
     },
     {
@@ -37,28 +37,72 @@
         "key": "property",
         "name": "Property trigger",
         "result": [
-            "/**"
+            "/**",
+            " * ${1:Undocumented variable}",
+            " *",
+            " * @var ${2:[type]}",
+            " */"
         ]
     },
     {
         "key": "function",
         "name": "Function trigger",
         "result": [
-            "/**"
+            "/**",
+            " * ${1:Undocumented function}",
+            " *",
+            " * @return ${2:void}",
+            " */"
         ]
     },
     {
         "key": "class",
         "name": "Class trigger",
         "result": [
-            "/**"
+            "/**",
+            " * ${1:Undocumented class}",
+            " */"
+        ]
+    },
+    {
+        "key": "variable",
+        "result": [
+            "/** @var ${1:[type]} $${2:var} ${3} */"
+        ]
+    },
+    {
+        "key": "foreach",
+        "result": [
+            "/** @var ${1:[type]} $${2:value} ${3} */"
+        ]
+    },
+    {
+        "key": "foreach-with-key",
+        "result": [
+            "/** @var ${1:[type]} $${2:value} ${3} */"
+        ]
+    },
+    {
+        "key": "while",
+        "result": [
+            "/** @var ${1:[type]} $${2:value} ${3} */"
+        ]
+    },
+    {
+        "key": "while-no-var",
+        "result": [
+            "/**",
+            " * ${1}",
+            " */"
         ]
     },
     {
         "key": "empty",
         "name": "Empty trigger",
         "result": [
-            "/**"
+            "/**",
+            " * ${1}",
+            " */"
         ]
     }
 ]

--- a/test/fixtures/variables.php
+++ b/test/fixtures/variables.php
@@ -1,0 +1,91 @@
+<?php
+
+////=> doc
+$var = 1;
+
+////=> float1
+$var = .3;
+
+////=> float2
+$var = 0.3;
+
+////=> float3
+$var = .1_000_1;
+
+////=> int1
+$var = 3;
+
+////=> int2
+$var = 03;
+
+////=> int3
+$var = 1_000_000;
+
+////=> bool1
+$var = true;
+
+////=> bool2
+$var = !0;
+
+////=> bool3
+$var = !'test';
+
+////=> stdclass
+$var = new stdClass;
+
+////=> object
+$var = new class {};
+
+////=> string1
+$var = 'string';
+
+////=> string2
+$var = "string";
+
+////=> string3
+$var = <<<EOF
+string
+EOF;
+
+////=> closure
+$var = function () {};
+
+////=> closure-fn
+$var = fn () => 123;
+
+////=> array1
+$var = [1,2,3];
+
+////=> array2
+$var = [];
+
+////=> array3
+$var = array(
+    1
+);
+
+////=> array4
+$var = [
+    1
+];
+
+////=> type-casting-string
+$var = (string)1;
+
+////=> type-casting-float1
+$var = (float)1;
+
+////=> type-casting-float2
+$var = (real)1;
+
+////=> type-casting-float3
+$var = (double)1;
+
+////=> type-casting-null
+$var = (unset)1;
+
+////=> mixed1
+$var = test();
+
+////=> mixed2
+$var = null;

--- a/test/fixtures/variables.php.json
+++ b/test/fixtures/variables.php.json
@@ -1,0 +1,176 @@
+[
+    {
+        "key": "doc",
+        "config": {
+            "inline": true
+        },
+        "result": {
+            "inline": true,
+            "message": "var",
+            "var": "integer"
+        },
+        "doc": "/** @var ${1:integer} $${2:var} ${3} */"
+    },
+    {
+        "key": "float1",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "float2",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "float3",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "int1",
+        "result": {
+            "var": "integer"
+        }
+    },
+    {
+        "key": "int2",
+        "result": {
+            "var": "integer"
+        }
+    },
+    {
+        "key": "int3",
+        "result": {
+            "var": "integer"
+        }
+    },
+    {
+        "key": "bool1",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "bool2",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "bool3",
+        "result": {
+            "var": "boolean"
+        }
+    },
+    {
+        "key": "stdclass",
+        "result": {
+            "var": "stdClass"
+        }
+    },
+    {
+        "key": "object",
+        "result": {
+            "var": "object"
+        }
+    },
+    {
+        "key": "string1",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "string2",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "string3",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "closure",
+        "result": {
+            "var": "\\Closure"
+        }
+    },
+    {
+        "key": "closure-fn",
+        "result": {
+            "var": "\\Closure"
+        }
+    },
+    {
+        "key": "array2",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array2",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array3",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "array4",
+        "result": {
+            "var": "array"
+        }
+    },
+    {
+        "key": "type-casting-string",
+        "result": {
+            "var": "string"
+        }
+    },
+    {
+        "key": "type-casting-float1",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-float2",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-float3",
+        "result": {
+            "var": "float"
+        }
+    },
+    {
+        "key": "type-casting-null",
+        "result": {
+            "var": "null"
+        }
+    },
+    {
+        "key": "mixed1",
+        "result": {
+            "var": "[type]"
+        }
+    },
+    {
+        "key": "mixed2",
+        "result": {
+            "var": "[type]"
+        }
+    }
+]

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import {TextEditor, TextDocument, WorkspaceConfiguration} from 'vscode';
+import Helper from './helpers';
+import Function from '../src/block/function';
+import {Doc, Param} from '../src/doc';
+import Config from '../src/util/config';
+import VariableBlock from '../src/block/VariableBlock';
+
+suite("Variable tests", () => {
+    let editor:TextEditor;
+    let document:TextDocument;
+    let testPositions:any = {};
+
+    let defaults:Config = Helper.getConfig();
+    let map = Helper.getFixtureMap('variables.php.json');
+
+    suiteSetup(function(done) {
+        Helper.loadFixture('variables.php', (edit:TextEditor, doc:TextDocument) => {
+            editor = edit;
+            document = doc;
+            testPositions = Helper.getFixturePositions(document);
+            done();
+        });
+    });
+
+    map.forEach(testData => {
+        if (testData.name === undefined) {
+            testData.name = testData.key;
+        }
+
+        test("Match Test: "+ testData.name, () => {
+            let variable = new VariableBlock(testPositions[testData.key], editor);
+            assert.equal(variable.test(), true, test.name);
+        });
+
+        test("Parse Test: "+ testData.name, () => {
+            let variable = new VariableBlock(testPositions[testData.key], editor);
+            assert.ok(variable.parse(), test.name);
+        });
+
+        test("Type Test: "+ testData.name, () => {
+            Helper.setConfig(testData.config);
+            let variable = new VariableBlock(testPositions[testData.key], editor);
+            let actual:Doc = variable.parse();
+            let expected:Doc = new Doc(testData.key.substring(1));
+            if (testData.result.var === undefined) {
+                expected.var = undefined;
+            }
+            expected.fromObject(actual);
+            expected.fromObject(testData.result);
+            assert.deepEqual(actual, expected);
+
+            if (testData.doc !== undefined) {
+                // if (isArray(testData.doc)) {
+                //     testData.doc = testData.doc.join("\n");
+                // }
+                assert.equal(actual.build().value, testData.doc, test.name);
+            }
+        });
+    });
+});


### PR DESCRIPTION
**Change Summary**:
Supported variable docblock
```php
# Example

/** @var int $var  */
$var = 1;

/** @var stdClass $object  */
$object = new stdClass;

/** @var \Closure $callback  */
$callback = function () {};
$callback = fn () => 1;

/** @var [type] $item  */
foreach ($data as $item) {}

/** @var [type] $item  */
while ($item = array_pop($data)) {}
```

**Checks**:
* [x] `CHANGELOG.md` updated with relavent changes

**Related issues**:
#228
#106
